### PR TITLE
Fix crashing issue after swipe dismissed a group item (#64)

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
@@ -444,6 +444,8 @@ class ExpandablePositionTranslator {
             mCachedGroupPosInfo[i] = mCachedGroupPosInfo[i + 1];
             mCachedGroupId[i] = mCachedGroupId[i + 1];
         }
+
+        mEndOfCalculatedOffsetGroupPosition = (mGroupCount == 0) ? RecyclerView.NO_POSITION : Math.max(0, groupPosition - 1);
     }
 
     public void removeChildItem(int groupPosition, int childPosition) {


### PR DESCRIPTION
This commit fixed the issue #64.

I forgot to update the mEndOfCalculatedOffsetGroupPosition field, so the internal state of ExpandablePositionTranslator gets corrupted when removing a group item :disappointed: