### PR TITLE
remove extra call to getDataProvider() and extra reference to mAdapter

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e/RecyclerListViewFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e/RecyclerListViewFragment.java
@@ -67,7 +67,6 @@ public class RecyclerListViewFragment extends Fragment {
         mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
 
         //adapter
-        getDataProvider();
         final MyExpandableItemAdapter myItemAdapter = new MyExpandableItemAdapter(getDataProvider());
 
         mAdapter = myItemAdapter;

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e/RecyclerListViewFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e/RecyclerListViewFragment.java
@@ -42,7 +42,6 @@ public class RecyclerListViewFragment extends Fragment {
 
     private RecyclerView mRecyclerView;
     private RecyclerView.LayoutManager mLayoutManager;
-    private RecyclerView.Adapter mAdapter;
     private RecyclerView.Adapter mWrappedAdapter;
     private RecyclerViewExpandableItemManager mRecyclerViewExpandableItemManager;
 
@@ -68,8 +67,6 @@ public class RecyclerListViewFragment extends Fragment {
 
         //adapter
         final MyExpandableItemAdapter myItemAdapter = new MyExpandableItemAdapter(getDataProvider());
-
-        mAdapter = myItemAdapter;
 
         mWrappedAdapter = mRecyclerViewExpandableItemManager.createWrappedAdapter(myItemAdapter);       // wrap for expanding
 
@@ -125,7 +122,6 @@ public class RecyclerListViewFragment extends Fragment {
             WrapperAdapterUtils.releaseAll(mWrappedAdapter);
             mWrappedAdapter = null;
         }
-        mAdapter = null;
         mLayoutManager = null;
 
         super.onDestroyView();


### PR DESCRIPTION
* A `getDataProvider()` call seems to be extraneous. It returns a `AbstractExpandableDataProvider` but nothing is done with it.

* I also removed the reference to `mAdapter` in `RecyclerListViewFragment`, as it was assigned but never accessed.