### PR TITLE
Created method to notify the insertion of expanded groups in range

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
@@ -830,6 +830,21 @@ class ExpandableRecyclerViewWrapperAdapter
         }
     }
 
+    /*package*/ void notifyExpandedGroupItemRangeInserted(int groupPositionStart, int count) {
+        int totalChildsAndGroupsInserted = 0;
+
+        for (int i = 0; i < count; ++i) {
+            int groupPosition = groupPositionStart + i;
+            int childCount = mPositionTranslator.getChildCount(groupPosition);
+
+            mPositionTranslator.expandGroup(groupPosition);
+
+            totalChildsAndGroupsInserted += (childCount + 1);
+        }
+
+        notifyItemRangeInserted(groupPositionStart, totalChildsAndGroupsInserted);
+    }
+
     /*package*/ void notifyGroupItemRemoved(int groupPosition) {
         final long packedPosition = ExpandableAdapterHelper.getPackedPositionForGroup(groupPosition);
         final int flatPosition = mPositionTranslator.getFlatPosition(packedPosition);

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
@@ -677,6 +677,29 @@ public class RecyclerViewExpandableItemManager {
         mAdapter.notifyGroupItemRangeInserted(groupPositionStart, itemCount);
     }
 
+    /**
+     * Notify any registered observers that the currently reflected <code>itemCount</code>
+     * group items starting at <code>groupPositionStart</code> have been newly inserted. The group items
+     * previously located at <code>groupPositionStart</code> and beyond can now be found starting
+     * at position <code>groupPositionStart + itemCount</code>.
+     *
+     * <p>This is a structural change event. Representations of other existing items in the
+     * data set are still considered up to date and will not be rebound, though their positions
+     * may be altered.</p>
+     *
+     * @param groupPositionStart Position of the first group item that was inserted
+     * @param itemCount Number of group items inserted
+     * @param expanded Wheter the groups will be inserted already expanded
+     *
+     * @see #notifyGroupItemRangeInserted(int, int)
+     */
+    public void notifyGroupItemRangeInserted(int groupPositionStart, int itemCount, boolean expanded) {
+        if (!expanded) {
+            notifyGroupItemRangeInserted(groupPositionStart, itemCount);
+        } else {
+            mAdapter.notifyExpandedGroupItemRangeInserted(groupPositionStart, itemCount);
+        }
+    }
 
     /**
      * Notify any registered observers that the group item reflected at <code>groupPosition</code>

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
@@ -679,8 +679,8 @@ public class RecyclerViewExpandableItemManager {
 
     /**
      * Notify any registered observers that the currently reflected <code>itemCount</code>
-     * group items starting at <code>groupPositionStart</code> have been newly inserted. The group items
-     * previously located at <code>groupPositionStart</code> and beyond can now be found starting
+     * group items starting at <code>groupPositionStart</code> have been newly inserted and may be <code>expanded</code>.
+     * The group items previously located at <code>groupPositionStart</code> and beyond can now be found starting
      * at position <code>groupPositionStart + itemCount</code>.
      *
      * <p>This is a structural change event. Representations of other existing items in the
@@ -689,7 +689,7 @@ public class RecyclerViewExpandableItemManager {
      *
      * @param groupPositionStart Position of the first group item that was inserted
      * @param itemCount Number of group items inserted
-     * @param expanded Wheter the groups will be inserted already expanded
+     * @param expanded Whether the groups will be inserted already expanded
      *
      * @see #notifyGroupItemRangeInserted(int, int)
      */


### PR DESCRIPTION
As suggested in this issue #57.

I created a method in `RecyclerViewExpandableItemManager` and `ExpandableRecyclerViewWrapperAdapter` to allow the insertion of already expanded groups.

So there is no need to call `RecyclerViewExpandableItemManager.expandGroup` for each Group, and consequently the overhead of calling `notifyItemRangeInserted` and `notifyItemChanged`.

I've made an example in `example` module, but i found a problem with `Indicator`, if you need i can commit it too.

If you have any suggestion about code standard or any issue with my code, i'm glad to help :D