### PR TITLE
Expose ability to cancel the dragdrop listener if user is pressing li…

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/RecyclerListViewFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/RecyclerListViewFragment.java
@@ -92,6 +92,15 @@ public class RecyclerListViewFragment extends Fragment {
 
         mRecyclerViewDragDropManager.attachRecyclerView(mRecyclerView);
 
+        mRecyclerView.addOnScrollListener(new RecyclerView.OnScrollListener() {
+            @Override
+            public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+                mRecyclerViewDragDropManager.cancelLongPressDetection();
+
+                super.onScrollStateChanged(recyclerView, newState);
+            }
+        });
+
         // for debugging
 //        animator.setDebug(true);
 //        animator.setMoveDuration(2000);

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -1553,6 +1553,10 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         }
     }
 
+    public void cancelLongPressDetection() {
+        mHandler.cancelLongPressDetection();
+    }
+
     private static class InternalHandler extends Handler {
         private static final int LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout();// + ViewConfiguration.getTapTimeout();
         private static final int MSG_LONGPRESS = 1;


### PR DESCRIPTION
Fixes #124 ... This exposes the ability to cancel the long press timeout that waits for long press to complete to begin a drag. The idea is that the app should be able to cancel the long press when the recycler view starts to scroll. I have tested that this successfully allows me to scroll a RecyclerView while also accepting a drag-drop re-order by dragging anywhere within an item. This is done by calling `cancelLongPressDetection` inside a `RecyclerView.OnScrollListener.onScrollStateChanged`  