### PR TITLE
Feature/fix long press event handling

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/RecyclerListViewFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/RecyclerListViewFragment.java
@@ -67,6 +67,7 @@ public class RecyclerListViewFragment extends Fragment {
         // Start dragging after long press
         mRecyclerViewDragDropManager.setInitiateOnLongPress(true);
         mRecyclerViewDragDropManager.setInitiateOnMove(false);
+        mRecyclerViewDragDropManager.setLongPressTimeout(750);
 
         //adapter
         final MyDraggableItemAdapter myItemAdapter = new MyDraggableItemAdapter(getDataProvider());

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -470,7 +470,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         switch (action) {
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
-                handleActionUpOrCancel(rv, e);
+                handleActionUpOrCancel(action, true);
                 break;
 
             case MotionEvent.ACTION_DOWN:
@@ -509,7 +509,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         switch (action) {
             case MotionEvent.ACTION_UP:
             case MotionEvent.ACTION_CANCEL:
-                handleActionUpOrCancel(rv, e);
+                handleActionUpOrCancel(action, true);
                 break;
 
             case MotionEvent.ACTION_MOVE:
@@ -645,6 +645,8 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
     }
 
     private void cancelDrag(boolean immediately) {
+        handleActionUpOrCancel(MotionEvent.ACTION_CANCEL, false);
+
         if (immediately) {
             finishDragging(false);
         } else {
@@ -749,8 +751,8 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         }
     }
 
-    private boolean handleActionUpOrCancel(RecyclerView rv, MotionEvent e) {
-        final boolean result = (MotionEventCompat.getActionMasked(e) == MotionEvent.ACTION_UP);
+    private boolean handleActionUpOrCancel(int action, boolean invokeFinish) {
+        final boolean result = (action == MotionEvent.ACTION_UP);
 
         mHandler.cancelLongPressDetection();
 
@@ -768,7 +770,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         mCanDragH = false;
         mCanDragV = false;
 
-        if (isDragging()) {
+        if (invokeFinish && isDragging()) {
             if (LOCAL_LOGD) {
                 Log.d(TAG, "dragging finished  --- result = " + result);
             }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -122,6 +122,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
     private long mInitialTouchItemId = RecyclerView.NO_ID;
     private boolean mInitiateOnLongPress;
     private boolean mInitiateOnMove = true;
+    private int mLongPressTimeout;
 
     private boolean mInScrollByMethod;
     private int mActualScrollByXAmount;
@@ -192,6 +193,8 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         };
 
         mScrollOnDraggingProcess = new ScrollOnDraggingProcessRunnable(this);
+
+        mLongPressTimeout = ViewConfiguration.getLongPressTimeout();
     }
 
     /**
@@ -283,7 +286,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         mDisplayDensity = mRecyclerView.getResources().getDisplayMetrics().density;
         mTouchSlop = ViewConfiguration.get(mRecyclerView.getContext()).getScaledTouchSlop();
         mScrollTouchSlop = (int) (mTouchSlop * SCROLL_TOUCH_SLOP_MULTIPLY + 0.5f);
-        mHandler = new InternalHandler(this);
+        mHandler = new InternalHandler(this, mLongPressTimeout);
 
         if (supportsEdgeEffect()) {
             // edge effect is available on ICS or later
@@ -399,6 +402,15 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
      */
     public void setInitiateOnMove(boolean initiateOnMove) {
         mInitiateOnMove = initiateOnMove;
+    }
+
+    /**
+     * Sets the time required to consider press as long press. (default: 500ms)
+     *
+     * @param longPressTimeout Integer in milli seconds.
+     */
+    public void setLongPressTimeout(int longPressTimeout) {
+        mLongPressTimeout = longPressTimeout;
     }
 
     /**
@@ -1554,14 +1566,15 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
     }
 
     private static class InternalHandler extends Handler {
-        private static final int LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout();// + ViewConfiguration.getTapTimeout();
+        private final int LONGPRESS_TIMEOUT;// + ViewConfiguration.getTapTimeout();
         private static final int MSG_LONGPRESS = 1;
 
         private RecyclerViewDragDropManager mHolder;
         private MotionEvent mDownMotionEvent;
 
-        public InternalHandler(RecyclerViewDragDropManager holder) {
+        public InternalHandler(RecyclerViewDragDropManager holder, int longPressTimeout) {
             mHolder = holder;
+            LONGPRESS_TIMEOUT = longPressTimeout;
         }
 
         public void release() {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -286,7 +286,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         mDisplayDensity = mRecyclerView.getResources().getDisplayMetrics().density;
         mTouchSlop = ViewConfiguration.get(mRecyclerView.getContext()).getScaledTouchSlop();
         mScrollTouchSlop = (int) (mTouchSlop * SCROLL_TOUCH_SLOP_MULTIPLY + 0.5f);
-        mHandler = new InternalHandler(this, mLongPressTimeout);
+        mHandler = new InternalHandler(this);
 
         if (supportsEdgeEffect()) {
             // edge effect is available on ICS or later
@@ -564,7 +564,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
 
 
         if (mInitiateOnLongPress) {
-            mHandler.startLongPressDetection(e);
+            mHandler.startLongPressDetection(e, mLongPressTimeout);
         }
 
         return true;
@@ -1566,15 +1566,13 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
     }
 
     private static class InternalHandler extends Handler {
-        private final int LONGPRESS_TIMEOUT;// + ViewConfiguration.getTapTimeout();
         private static final int MSG_LONGPRESS = 1;
 
         private RecyclerViewDragDropManager mHolder;
         private MotionEvent mDownMotionEvent;
 
-        public InternalHandler(RecyclerViewDragDropManager holder, int longPressTimeout) {
+        public InternalHandler(RecyclerViewDragDropManager holder) {
             mHolder = holder;
-            LONGPRESS_TIMEOUT = longPressTimeout;
         }
 
         public void release() {
@@ -1591,10 +1589,10 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
             }
         }
 
-        public void startLongPressDetection(MotionEvent e) {
+        public void startLongPressDetection(MotionEvent e, int timeout) {
             cancelLongPressDetection();
             mDownMotionEvent = MotionEvent.obtain(e);
-            sendEmptyMessageAtTime(MSG_LONGPRESS, e.getDownTime() + LONGPRESS_TIMEOUT);
+            sendEmptyMessageAtTime(MSG_LONGPRESS, e.getDownTime() + timeout);
         }
 
         public void cancelLongPressDetection() {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -541,6 +541,10 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         if (LOCAL_LOGV) {
             Log.v(TAG, "onScrollStateChanged(newState = " + newState + ")");
         }
+
+        if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+            cancelDrag(true);
+        }
     }
 
     private boolean handleActionDown(RecyclerView rv, MotionEvent e) {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
@@ -100,6 +100,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
     private SwipingItemOperator mSwipingItemOperator;
     private OnItemSwipeEventListener mItemSwipeEventListener;
     private InternalHandler mHandler;
+    private int mLongPressTimeout;
 
     /**
      * Constructor.
@@ -121,6 +122,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
             }
         };
         mVelocityTracker = VelocityTracker.obtain();
+        mLongPressTimeout = ViewConfiguration.getLongPressTimeout();
     }
 
     /**
@@ -234,6 +236,15 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         return (mSwipingItem != null);
     }
 
+    /**
+     * Sets the time required to consider press as long press. (default: 500ms)
+     *
+     * @param longPressTimeout Integer in milli seconds.
+     */
+    public void setLongPressTimeout(int longPressTimeout) {
+        mLongPressTimeout = longPressTimeout;
+    }
+
     /*package*/ boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
         final int action = MotionEventCompat.getActionMasked(e);
 
@@ -337,7 +348,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         mSwipingItemReactionType = reactionType;
 
         if ((reactionType & REACTION_START_SWIPE_ON_LONG_PRESS) != 0) {
-            mHandler.startLongPressDetection(e);
+            mHandler.startLongPressDetection(e, mLongPressTimeout);
         }
 
         return true;
@@ -803,7 +814,6 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
     }
 
     private static class InternalHandler extends Handler {
-        private static final int LONGPRESS_TIMEOUT = ViewConfiguration.getLongPressTimeout();// + ViewConfiguration.getTapTimeout();
         private static final int MSG_LONGPRESS = 1;
 
         private RecyclerViewSwipeManager mHolder;
@@ -827,10 +837,10 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
             }
         }
 
-        public void startLongPressDetection(MotionEvent e) {
+        public void startLongPressDetection(MotionEvent e, int timeout) {
             cancelLongPressDetection();
             mDownMotionEvent = MotionEvent.obtain(e);
-            sendEmptyMessageAtTime(MSG_LONGPRESS, e.getDownTime() + LONGPRESS_TIMEOUT);
+            sendEmptyMessageAtTime(MSG_LONGPRESS, e.getDownTime() + timeout);
         }
 
         public void cancelLongPressDetection() {


### PR DESCRIPTION
This PR includes these fixes/modifications;

- Merge the PR #123 (Feature : API to set longpress timeout for drag drop)
- Fix the issue #124 (Long press should cancel when recycler view scroll)
- Add the `RecyclerViewSwipeManager.setLongPressTimeout()` method
- Cancel drag drop/swipe when the `RecyclerView.requestDisallowInterceptTouchEvent(true)` is called