### PR TITLE
Optimization: Change neutral bg from white to transparent

### DIFF
--- a/example/src/main/res/drawable/bg_swipe_item_neutral.xml
+++ b/example/src/main/res/drawable/bg_swipe_item_neutral.xml
@@ -16,4 +16,4 @@
 -->
 <color
     xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="@color/bg_swipe_item_neutral"/>
+    android:color="@android:color/transparent"/>


### PR DESCRIPTION
Changing the bg_swipe_item_neutral.xml color from white to transparent greatly reduces the amount of GPU overdraw in the app and thus giving you more FPS!