### PR TITLE
Implement onItemDragMoveDistanceUpdated() callback

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggingItemDecorator.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggingItemDecorator.java
@@ -142,7 +142,7 @@ class DraggingItemDecorator extends BaseDraggableItemDecorator {
         // hide
         itemView.setVisibility(View.INVISIBLE);
 
-        update(e);
+        update(e, true);
 
         mRecyclerView.addItemDecoration(this);
 
@@ -189,17 +189,27 @@ class DraggingItemDecorator extends BaseDraggableItemDecorator {
         mStarted = false;
     }
 
-    public void update(MotionEvent e) {
+    public boolean update(MotionEvent e, boolean force) {
         mTouchPositionX = (int) (e.getX() + 0.5f);
         mTouchPositionY = (int) (e.getY() + 0.5f);
-        refresh();
+
+        return refresh(force);
     }
 
-    public void refresh() {
-        updateTranslationOffset();
-        updateDraggingItemPosition(mTranslationX, mTranslationY);
+    public boolean refresh(boolean force) {
+        final int prevTranslationX = mTranslationX;
+        final int prevTranslationY = mTranslationY;
 
-        ViewCompat.postInvalidateOnAnimation(mRecyclerView);
+        updateTranslationOffset();
+
+        final boolean updated = (prevTranslationX != mTranslationX) || (prevTranslationY != mTranslationY);
+
+        if (updated || force) {
+            updateDraggingItemPosition(mTranslationX, mTranslationY);
+            ViewCompat.postInvalidateOnAnimation(mRecyclerView);
+        }
+
+        return updated;
     }
 
     public void setShadowDrawable(NinePatchDrawable shadowDrawable) {
@@ -216,6 +226,14 @@ class DraggingItemDecorator extends BaseDraggableItemDecorator {
 
     public int getDraggingItemTranslationX() {
         return mTranslationX;
+    }
+
+    public int getDraggingItemMoveOffsetY() {
+        return mTranslationY - mDraggingItemInfo.initialItemTop;
+    }
+
+    public int getDraggingItemMoveOffsetX() {
+        return mTranslationX - mDraggingItemInfo.initialItemLeft;
     }
 
     private void updateTranslationOffset() {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggingItemInfo.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggingItemInfo.java
@@ -25,6 +25,8 @@ public class DraggingItemInfo {
     public final int width;
     public final int height;
     public final long id;
+    public final int initialItemLeft;
+    public final int initialItemTop;
     public final int grabbedPositionX;
     public final int grabbedPositionY;
     public final Rect margins;
@@ -33,8 +35,10 @@ public class DraggingItemInfo {
         width = vh.itemView.getWidth();
         height = vh.itemView.getHeight();
         id = vh.getItemId();
-        grabbedPositionX = touchX - vh.itemView.getLeft();
-        grabbedPositionY = touchY - vh.itemView.getTop();
+        initialItemLeft = vh.itemView.getLeft();
+        initialItemTop = vh.itemView.getTop();
+        grabbedPositionX = touchX - initialItemLeft;
+        grabbedPositionY = touchY - initialItemTop;
         margins = new Rect();
         CustomRecyclerViewUtils.getLayoutMargins(vh.itemView, margins);
     }


### PR DESCRIPTION
Add `onItemDragMoveDistanceUpdated()` callback to `OnItemDragEventListener`.

```java
    public interface OnItemDragEventListener {
        /**
         * Callback method to be invoked when the distance of currently dragging item is updated.
         *
         * @param offsetX The horizontal distance of currently dragging item from the initial position in pixels.
         * @param offsetY The vertical distance of currently dragging item from the initial position in pixels.
         */
        void onItemDragMoveDistanceUpdated(int offsetX, int offsetY);
    }
```

ref.) #191 

