### PR TITLE
Feature/support check can drop callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Please check the implementation of the simple examples.
 - [Draggable staggered grid](example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_staggered_grid/)
 - [Draggable with section](example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_with_section/)
 - [Drag on Long press](example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/)
+- [Uses onCheckCanDrop()](example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/)
 
 ### Expandable item related examples
 

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -57,6 +57,10 @@
             android:label="@string/activity_title_demo_d_on_longpress"/>
 
         <activity
+            android:name=".demo_d_check_can_drop.DraggableCheckCanDropExampleActivity"
+            android:label="@string/activity_title_demo_d_check_can_drop"/>
+
+        <activity
             android:name=".demo_s_minimal.MinimalSwipeableExampleActivity"
             android:label="@string/activity_title_demo_s_minimal"/>
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_basic/DraggableExampleItemAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_basic/DraggableExampleItemAdapter.java
@@ -146,4 +146,9 @@ class DraggableExampleItemAdapter
         // no drag-sortable range specified
         return null;
     }
+
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleActivity.java
@@ -1,0 +1,50 @@
+/*
+ *    Copyright (C) 2015 Haruki Hasegawa
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.h6ah4i.android.example.advrecyclerview.demo_d_check_can_drop;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatActivity;
+
+import com.h6ah4i.android.example.advrecyclerview.R;
+import com.h6ah4i.android.example.advrecyclerview.common.data.AbstractDataProvider;
+import com.h6ah4i.android.example.advrecyclerview.common.fragment.ExampleDataProviderFragment;
+
+public class DraggableCheckCanDropExampleActivity extends AppCompatActivity {
+    private static final String FRAGMENT_TAG_DATA_PROVIDER = "data provider";
+    private static final String FRAGMENT_LIST_VIEW = "list view";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_demo);
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager().beginTransaction()
+                    .add(new ExampleDataProviderFragment(), FRAGMENT_TAG_DATA_PROVIDER)
+                    .commit();
+            getSupportFragmentManager().beginTransaction()
+                    .add(R.id.container, new DraggableCheckCanDropExampleFragment(), FRAGMENT_LIST_VIEW)
+                    .commit();
+        }
+    }
+
+    public AbstractDataProvider getDataProvider() {
+        final Fragment fragment = getSupportFragmentManager().findFragmentByTag(FRAGMENT_TAG_DATA_PROVIDER);
+        return ((ExampleDataProviderFragment) fragment).getDataProvider();
+    }
+}

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleFragment.java
@@ -1,0 +1,134 @@
+/*
+ *    Copyright (C) 2015 Haruki Hasegawa
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.h6ah4i.android.example.advrecyclerview.demo_d_check_can_drop;
+
+import android.graphics.drawable.NinePatchDrawable;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.h6ah4i.android.example.advrecyclerview.R;
+import com.h6ah4i.android.example.advrecyclerview.common.data.AbstractDataProvider;
+import com.h6ah4i.android.widget.advrecyclerview.animator.GeneralItemAnimator;
+import com.h6ah4i.android.widget.advrecyclerview.animator.RefactoredDefaultItemAnimator;
+import com.h6ah4i.android.widget.advrecyclerview.decoration.ItemShadowDecorator;
+import com.h6ah4i.android.widget.advrecyclerview.decoration.SimpleListDividerDecorator;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
+import com.h6ah4i.android.widget.advrecyclerview.utils.WrapperAdapterUtils;
+
+public class DraggableCheckCanDropExampleFragment extends Fragment {
+    private RecyclerView mRecyclerView;
+    private RecyclerView.LayoutManager mLayoutManager;
+    private RecyclerView.Adapter mAdapter;
+    private RecyclerView.Adapter mWrappedAdapter;
+    private RecyclerViewDragDropManager mRecyclerViewDragDropManager;
+
+    public DraggableCheckCanDropExampleFragment() {
+        super();
+    }
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_recycler_list_view, container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        //noinspection ConstantConditions
+        mRecyclerView = (RecyclerView) getView().findViewById(R.id.recycler_view);
+        mLayoutManager = new LinearLayoutManager(getContext(), LinearLayoutManager.VERTICAL, false);
+
+        // drag & drop manager
+        mRecyclerViewDragDropManager = new RecyclerViewDragDropManager();
+        mRecyclerViewDragDropManager.setDraggingItemShadowDrawable(
+                (NinePatchDrawable) ContextCompat.getDrawable(getContext(), R.drawable.material_shadow_z3));
+        mRecyclerViewDragDropManager.setCheckCanDropEnabled(true); // !!! this method is required to use onCheckCanDrop()
+
+        //adapter
+        final DraggableCheckCanDropExampleItemAdapter myItemAdapter = new DraggableCheckCanDropExampleItemAdapter(getDataProvider());
+        mAdapter = myItemAdapter;
+
+        mWrappedAdapter = mRecyclerViewDragDropManager.createWrappedAdapter(myItemAdapter);      // wrap for dragging
+
+        final GeneralItemAnimator animator = new RefactoredDefaultItemAnimator();
+
+        mRecyclerView.setLayoutManager(mLayoutManager);
+        mRecyclerView.setAdapter(mWrappedAdapter);  // requires *wrapped* adapter
+        mRecyclerView.setItemAnimator(animator);
+
+        // additional decorations
+        //noinspection StatementWithEmptyBody
+        if (supportsViewElevation()) {
+            // Lollipop or later has native drop shadow feature. ItemShadowDecorator is not required.
+        } else {
+            mRecyclerView.addItemDecoration(new ItemShadowDecorator((NinePatchDrawable) ContextCompat.getDrawable(getContext(), R.drawable.material_shadow_z1)));
+        }
+        mRecyclerView.addItemDecoration(new SimpleListDividerDecorator(ContextCompat.getDrawable(getContext(), R.drawable.list_divider_h), true));
+
+        mRecyclerViewDragDropManager.attachRecyclerView(mRecyclerView);
+
+        // for debugging
+//        animator.setDebug(true);
+//        animator.setMoveDuration(2000);
+    }
+
+    @Override
+    public void onPause() {
+        mRecyclerViewDragDropManager.cancelDrag();
+        super.onPause();
+    }
+
+    @Override
+    public void onDestroyView() {
+        if (mRecyclerViewDragDropManager != null) {
+            mRecyclerViewDragDropManager.release();
+            mRecyclerViewDragDropManager = null;
+        }
+
+        if (mRecyclerView != null) {
+            mRecyclerView.setItemAnimator(null);
+            mRecyclerView.setAdapter(null);
+            mRecyclerView = null;
+        }
+
+        if (mWrappedAdapter != null) {
+            WrapperAdapterUtils.releaseAll(mWrappedAdapter);
+            mWrappedAdapter = null;
+        }
+        mAdapter = null;
+        mLayoutManager = null;
+
+        super.onDestroyView();
+    }
+
+    private boolean supportsViewElevation() {
+        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP);
+    }
+
+    public AbstractDataProvider getDataProvider() {
+        return ((DraggableCheckCanDropExampleActivity) getActivity()).getDataProvider();
+    }
+}

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleItemAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleItemAdapter.java
@@ -1,0 +1,154 @@
+/*
+ *    Copyright (C) 2015 Haruki Hasegawa
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.h6ah4i.android.example.advrecyclerview.demo_d_check_can_drop;
+
+import android.support.v4.view.ViewCompat;
+import android.support.v7.widget.RecyclerView;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import com.h6ah4i.android.example.advrecyclerview.R;
+import com.h6ah4i.android.example.advrecyclerview.common.data.AbstractDataProvider;
+import com.h6ah4i.android.example.advrecyclerview.common.utils.DrawableUtils;
+import com.h6ah4i.android.example.advrecyclerview.common.utils.ViewUtils;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemAdapter;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemConstants;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.ItemDraggableRange;
+import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractDraggableItemViewHolder;
+
+class DraggableCheckCanDropExampleItemAdapter
+        extends RecyclerView.Adapter<DraggableCheckCanDropExampleItemAdapter.MyViewHolder>
+        implements DraggableItemAdapter<DraggableCheckCanDropExampleItemAdapter.MyViewHolder> {
+    private static final String TAG = "MyDraggableItemAdapter";
+
+    // NOTE: Make accessible with short name
+    private interface Draggable extends DraggableItemConstants {
+    }
+
+    private AbstractDataProvider mProvider;
+
+    public static class MyViewHolder extends AbstractDraggableItemViewHolder {
+        public FrameLayout mContainer;
+        public View mDragHandle;
+        public TextView mTextView;
+
+        public MyViewHolder(View v) {
+            super(v);
+            mContainer = (FrameLayout) v.findViewById(R.id.container);
+            mDragHandle = v.findViewById(R.id.drag_handle);
+            mTextView = (TextView) v.findViewById(android.R.id.text1);
+        }
+    }
+
+    public DraggableCheckCanDropExampleItemAdapter(AbstractDataProvider dataProvider) {
+        mProvider = dataProvider;
+
+        // DraggableItemAdapter requires stable ID, and also
+        // have to implement the getItemId() method appropriately.
+        setHasStableIds(true);
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return mProvider.getItem(position).getId();
+    }
+
+    @Override
+    public int getItemViewType(int position) {
+        return mProvider.getItem(position).getViewType();
+    }
+
+    @Override
+    public MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+        final LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        final View v = inflater.inflate((viewType == 0) ? R.layout.list_item_draggable : R.layout.list_item2_draggable, parent, false);
+        return new MyViewHolder(v);
+    }
+
+    @Override
+    public void onBindViewHolder(MyViewHolder holder, int position) {
+        final AbstractDataProvider.Data item = mProvider.getItem(position);
+
+        // set text
+        holder.mTextView.setText(item.getText());
+
+        // set background resource (target view ID: container)
+        final int dragState = holder.getDragStateFlags();
+
+        if (((dragState & Draggable.STATE_FLAG_IS_UPDATED) != 0)) {
+            int bgResId;
+
+            if ((dragState & Draggable.STATE_FLAG_IS_ACTIVE) != 0) {
+                bgResId = R.drawable.bg_item_dragging_active_state;
+
+                // need to clear drawable state here to get correct appearance of the dragging item.
+                DrawableUtils.clearState(holder.mContainer.getForeground());
+            } else if ((dragState & Draggable.STATE_FLAG_DRAGGING) != 0) {
+                bgResId = R.drawable.bg_item_dragging_state;
+            } else {
+                bgResId = R.drawable.bg_item_normal_state;
+            }
+
+            holder.mContainer.setBackgroundResource(bgResId);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return mProvider.getCount();
+    }
+
+    @Override
+    public void onMoveItem(int fromPosition, int toPosition) {
+        Log.d(TAG, "onMoveItem(fromPosition = " + fromPosition + ", toPosition = " + toPosition + ")");
+
+        if (fromPosition == toPosition) {
+            return;
+        }
+
+        mProvider.moveItem(fromPosition, toPosition);
+
+        notifyItemMoved(fromPosition, toPosition);
+    }
+
+    @Override
+    public boolean onCheckCanStartDrag(MyViewHolder holder, int position, int x, int y) {
+        // x, y --- relative from the itemView's top-left
+        final View containerView = holder.mContainer;
+        final View dragHandleView = holder.mDragHandle;
+
+        final int offsetX = containerView.getLeft() + (int) (ViewCompat.getTranslationX(containerView) + 0.5f);
+        final int offsetY = containerView.getTop() + (int) (ViewCompat.getTranslationY(containerView) + 0.5f);
+
+        return ViewUtils.hitTest(dragHandleView, x - offsetX, y - offsetY);
+    }
+
+    @Override
+    public ItemDraggableRange onGetItemDraggableRange(MyViewHolder holder, int position) {
+        // no drag-sortable range specified
+        return null;
+    }
+
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return (draggingPosition % 2) == (dropPosition % 2);
+    }
+}

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/DraggableGridExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/DraggableGridExampleAdapter.java
@@ -137,4 +137,9 @@ class DraggableGridExampleAdapter
         // no drag-sortable range specified
         return null;
     }
+
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_minimal/MinimalDraggableExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_minimal/MinimalDraggableExampleActivity.java
@@ -132,5 +132,10 @@ public class MinimalDraggableExampleActivity extends AppCompatActivity {
         public ItemDraggableRange onGetItemDraggableRange(MyViewHolder holder, int position) {
             return null;
         }
+
+        @Override
+        public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+            return true;
+        }
     }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/DragOnLongPressExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/DragOnLongPressExampleAdapter.java
@@ -146,4 +146,9 @@ class DragOnLongPressExampleAdapter
         // no drag-sortable range specified
         return null;
     }
+
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_staggered_grid/DraggableStaggeredGridExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_staggered_grid/DraggableStaggeredGridExampleAdapter.java
@@ -109,6 +109,10 @@ class DraggableStaggeredGridExampleAdapter
                 // NOTE:
                 // This dummy header item is required to workaround the
                 // weired animation when occurs on moving the item 0
+                //
+                // Related issue
+                //   Issue 99047:	Inconsistent behavior produced by mAdapter.notifyItemMoved(indexA,indexB);
+                //   https://code.google.com/p/android/issues/detail?id=99047&q=notifyItemMoved&colspec=ID%20Status%20Priority%20Owner%20Summary%20Stars%20Reporter%20Opened&
                 final View v = inflater.inflate(R.layout.dummy_header_item, parent, false);
                 return new HeaderItemViewHolder(v);
             }
@@ -205,6 +209,11 @@ class DraggableStaggeredGridExampleAdapter
     public ItemDraggableRange onGetItemDraggableRange(BaseViewHolder holder, int position) {
         int headerCount = getHeaderItemCount();
         return new ItemDraggableRange(headerCount, getItemCount() - 1);
+    }
+
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
     }
 
     static int getHeaderItemCount() {

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_with_section/DraggableWithSectionExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_with_section/DraggableWithSectionExampleAdapter.java
@@ -191,6 +191,11 @@ class DraggableWithSectionExampleAdapter
         return new ItemDraggableRange(start, end);
     }
 
+    @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
+    }
+
     private int findFirstSectionItem(int position) {
         AbstractDataProvider.Data item = mProvider.getItem(position);
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
@@ -214,6 +214,11 @@ class DraggableSwipeableExampleAdapter
     }
 
     @Override
+    public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
+        return true;
+    }
+
+    @Override
     public int onGetSwipeReactionType(MyViewHolder holder, int position, int x, int y) {
         if (onCheckCanStartDrag(holder, position, x, y)) {
             return Swipeable.REACTION_CAN_NOT_SWIPE_BOTH_H;

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleAdapter.java
@@ -332,6 +332,16 @@ class ExpandableDraggableWithSectionExampleAdapter
     }
 
     @Override
+    public boolean onCheckGroupCanDrop(int draggingGroupPosition, int dropGroupPosition) {
+        return true;
+    }
+
+    @Override
+    public boolean onCheckChildCanDrop(int draggingGroupPosition, int draggingChildPosition, int dropGroupPosition, int dropChildPosition) {
+        return true;
+    }
+
+    @Override
     public void onMoveGroupItem(int fromGroupPosition, int toGroupPosition) {
         mProvider.moveGroupItem(fromGroupPosition, toGroupPosition);
     }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
@@ -361,6 +361,16 @@ class ExpandableDraggableSwipeableExampleAdapter
     }
 
     @Override
+    public boolean onCheckGroupCanDrop(int draggingGroupPosition, int dropGroupPosition) {
+        return true;
+    }
+
+    @Override
+    public boolean onCheckChildCanDrop(int draggingGroupPosition, int draggingChildPosition, int dropGroupPosition, int dropChildPosition) {
+        return true;
+    }
+
+    @Override
     public void onMoveGroupItem(int fromGroupPosition, int toGroupPosition) {
         mProvider.moveGroupItem(fromGroupPosition, toGroupPosition);
     }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/launcher/LauncherPageFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/launcher/LauncherPageFragment.java
@@ -27,6 +27,7 @@ import android.view.ViewGroup;
 
 import com.h6ah4i.android.example.advrecyclerview.R;
 import com.h6ah4i.android.example.advrecyclerview.demo_d_basic.DraggableExampleActivity;
+import com.h6ah4i.android.example.advrecyclerview.demo_d_check_can_drop.DraggableCheckCanDropExampleActivity;
 import com.h6ah4i.android.example.advrecyclerview.demo_d_grid.DraggableGridExampleActivity;
 import com.h6ah4i.android.example.advrecyclerview.demo_d_minimal.MinimalDraggableExampleActivity;
 import com.h6ah4i.android.example.advrecyclerview.demo_d_on_longpress.DragOnLongPressExampleActivity;
@@ -91,6 +92,7 @@ public class LauncherPageFragment extends Fragment {
                 adapter.put(DraggableExampleActivity.class, R.string.activity_title_demo_d_basic);
                 adapter.put(DragOnLongPressExampleActivity.class, R.string.activity_title_demo_d_on_longpress);
                 adapter.put(DraggableWithSectionExampleActivity.class, R.string.activity_title_demo_d_with_section);
+                adapter.put(DraggableCheckCanDropExampleActivity.class, R.string.activity_title_demo_d_check_can_drop);
                 adapter.put(DraggableGridExampleActivity.class, R.string.activity_title_demo_d_grid);
                 adapter.put(DraggableStaggeredGridExampleActivity.class, R.string.activity_title_demo_d_staggered_grid);
                 break;

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="activity_title_demo_d_grid">Draggable (Grid Layout)</string>
     <string name="activity_title_demo_d_staggered_grid">Draggable (Staggered Grid Layout)</string>
     <string name="activity_title_demo_d_on_longpress">Drag on Long Press</string>
+    <string name="activity_title_demo_d_check_can_drop">Draggable (uses onCheckCanDrop)</string>
     <string name="activity_title_demo_s_minimal">Swipeable (Minimal)</string>
     <string name="activity_title_demo_s_basic">Swipeable (Basic)</string>
     <string name="activity_title_demo_s_on_longpress">Swipe on Long Press</string>

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemAdapter.java
@@ -50,4 +50,16 @@ public interface DraggableItemAdapter<T extends RecyclerView.ViewHolder> {
      * @param toPosition New position of the item.
      */
     void onMoveItem(int fromPosition, int toPosition);
+
+    /**
+     * Called while dragging in order to check whether the dragging item can be dropped to the specified position.
+     *
+     * NOTE: This method will be called when the checkCanDrop option is enabled by {@link RecyclerViewDragDropManager#setCheckCanDropEnabled(boolean)}.
+     *
+     * @param draggingPosition The position of the currently dragging item.
+     * @param dropPosition The position to check whether the dragging item can be dropped or not.
+     *
+     * @return Whether can be dropped to the specified position.
+     */
+    boolean onCheckCanDrop(int draggingPosition, int dropPosition);
 }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
@@ -311,6 +311,16 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
     // NOTE: This method is called from RecyclerViewDragDropManager
     /*package*/
     @SuppressWarnings("unchecked")
+    boolean canDropItems(int draggingPosition, int dropPosition) {
+        if (LOCAL_LOGV) {
+            Log.v(TAG, "canDropItems(draggingPosition = " + draggingPosition + ", dropPosition = " + dropPosition + ")");
+        }
+        return mDraggableItemAdapter.onCheckCanDrop(draggingPosition, dropPosition);
+    }
+
+    // NOTE: This method is called from RecyclerViewDragDropManager
+    /*package*/
+    @SuppressWarnings("unchecked")
     ItemDraggableRange getItemDraggableRange(RecyclerView.ViewHolder holder, int position) {
         if (LOCAL_LOGV) {
             Log.v(TAG, "getItemDraggableRange(holder = " + holder + ", position = " + position + ")");

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableDraggableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableDraggableItemAdapter.java
@@ -19,6 +19,7 @@ package com.h6ah4i.android.widget.advrecyclerview.expandable;
 import android.support.v7.widget.RecyclerView;
 
 import com.h6ah4i.android.widget.advrecyclerview.draggable.ItemDraggableRange;
+import com.h6ah4i.android.widget.advrecyclerview.draggable.RecyclerViewDragDropManager;
 
 public interface ExpandableDraggableItemAdapter<GVH extends RecyclerView.ViewHolder, CVH extends RecyclerView.ViewHolder> {
     /**
@@ -86,4 +87,32 @@ public interface ExpandableDraggableItemAdapter<GVH extends RecyclerView.ViewHol
      * @param toChildPosition New child position of the item.
      */
     void onMoveChildItem(int fromGroupPosition, int fromChildPosition, int toGroupPosition, int toChildPosition);
+
+
+    /**
+     * Called while dragging in order to check whether the dragging item can be dropped to the specified position.
+     *
+     * NOTE: This method will be called when the checkCanDrop option is enabled by {@link RecyclerViewDragDropManager#setCheckCanDropEnabled(boolean)}.
+     *
+     * @param draggingGroupPosition The position of the currently dragging group item.
+     * @param dropGroupPosition The position of a group item whether to check can be dropped or not.
+     *
+     * @return Whether can be dropped to the specified position.
+     */
+    boolean onCheckGroupCanDrop(int draggingGroupPosition, int dropGroupPosition);
+
+
+    /**
+     * Called while dragging in order to check whether the dragging item can be dropped to the specified position.
+     *
+     * NOTE: This method will be called when the checkCanDrop option is enabled by {@link RecyclerViewDragDropManager#setCheckCanDropEnabled(boolean)}.
+     *
+     * @param draggingGroupPosition The group position of the currently dragging item.
+     * @param draggingChildPosition The child position of the currently dragging item.
+     * @param dropGroupPosition The group position to check whether the dragging item can be dropped or not.
+     * @param dropChildPosition The child position to check whether the dragging item can be dropped or not.
+     *
+     * @return Whether can be dropped to the specified position.
+     */
+    boolean onCheckChildCanDrop(int draggingGroupPosition, int draggingChildPosition, int dropGroupPosition, int dropChildPosition);
 }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/CustomRecyclerViewUtils.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/CustomRecyclerViewUtils.java
@@ -212,8 +212,10 @@ public class CustomRecyclerViewUtils {
     }
 
     public static int getOrientation(@NonNull RecyclerView rv) {
-        RecyclerView.LayoutManager layoutManager = rv.getLayoutManager();
+        return getOrientation(rv.getLayoutManager());
+    }
 
+    public static int getOrientation(@NonNull RecyclerView.LayoutManager layoutManager) {
         if (layoutManager instanceof GridLayoutManager) {
             return ((GridLayoutManager) layoutManager).getOrientation();
         } else if (layoutManager instanceof LinearLayoutManager) {
@@ -261,5 +263,13 @@ public class CustomRecyclerViewUtils {
             }
         }
         return partiallyVisible;
+    }
+
+    public static int safeGetAdapterPosition(@Nullable RecyclerView.ViewHolder holder) {
+        return (holder != null) ? holder.getAdapterPosition() : RecyclerView.NO_POSITION;
+    }
+
+    public static View findViewByPosition(RecyclerView.LayoutManager layoutManager, int position) {
+        return (position != RecyclerView.NO_POSITION) ? layoutManager.findViewByPosition(position) : null;
     }
 }


### PR DESCRIPTION
This new API is discussng on the issue #223.

Thew newly added onCheckCanDrop() method is called before
the OnItemDragEventListener.onItemDragPositionChanged() callback.

Note that the new method will not be called until explicitly enable
it by the RecyclerViewDragDropManager.setCheckCanDropEnabled().

This commit also includes the following new methods.

- RecyclerViewDragDropManager.setCheckCanDropEnabled()
- RecyclerViewDragDropManager.isCheckCanDropEnabled()
- ExpandableDraggableItemAdapter.onCheckGroupCanDrop()
- ExpandableDraggableItemAdapter.onCheckChildCanDrop()
