### PR TITLE
Apply state for expanded list items

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_add_remove/AddRemoveExpandableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_add_remove/AddRemoveExpandableExampleFragment.java
@@ -72,9 +72,12 @@ public class AddRemoveExpandableExampleFragment
         mLayoutManager = new LinearLayoutManager(getContext());
 
         final Parcelable eimSavedState = (savedInstanceState != null) ? savedInstanceState.getParcelable(SAVED_STATE_EXPANDABLE_ITEM_MANAGER) : null;
-        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
+        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager();
         mRecyclerViewExpandableItemManager.setOnGroupExpandListener(this);
         mRecyclerViewExpandableItemManager.setOnGroupCollapseListener(this);
+
+        // state must be set after listeners are added
+        mRecyclerViewExpandableItemManager.setSavedState(eimSavedState);
 
         //adapter
         final AddRemoveExpandableExampleAdapter myItemAdapter = new AddRemoveExpandableExampleAdapter(mRecyclerViewExpandableItemManager, getDataProvider());

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_already_expanded/AlreadyExpandedGroupsExpandableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_already_expanded/AlreadyExpandedGroupsExpandableExampleFragment.java
@@ -69,7 +69,9 @@ public class AlreadyExpandedGroupsExpandableExampleFragment extends Fragment {
         mLayoutManager = new LinearLayoutManager(getContext());
 
         final Parcelable eimSavedState = (savedInstanceState != null) ? savedInstanceState.getParcelable(SAVED_STATE_EXPANDABLE_ITEM_MANAGER) : null;
-        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
+        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager();
+        // state must be set after listeners are added
+        mRecyclerViewExpandableItemManager.setSavedState(eimSavedState);
 
         //adapter
         final AlreadyExpandedGroupsExpandableExampleAdapter myItemAdapter = new AlreadyExpandedGroupsExpandableExampleAdapter(mRecyclerViewExpandableItemManager, getDataProvider());

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_basic/ExpandableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_basic/ExpandableExampleFragment.java
@@ -67,9 +67,12 @@ public class ExpandableExampleFragment
         mLayoutManager = new LinearLayoutManager(getContext());
 
         final Parcelable eimSavedState = (savedInstanceState != null) ? savedInstanceState.getParcelable(SAVED_STATE_EXPANDABLE_ITEM_MANAGER) : null;
-        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
+        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager();
         mRecyclerViewExpandableItemManager.setOnGroupExpandListener(this);
         mRecyclerViewExpandableItemManager.setOnGroupCollapseListener(this);
+
+        // state must be set after listeners are added
+        mRecyclerViewExpandableItemManager.setSavedState(eimSavedState);
 
         //adapter
         final ExpandableExampleAdapter myItemAdapter = new ExpandableExampleAdapter(getDataProvider());

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_minimal/MinimalExpandableExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_minimal/MinimalExpandableExampleActivity.java
@@ -24,15 +24,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
-
 import com.h6ah4i.android.example.advrecyclerview.R;
-import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemAdapter;
-import com.h6ah4i.android.widget.advrecyclerview.draggable.ItemDraggableRange;
 import com.h6ah4i.android.widget.advrecyclerview.expandable.RecyclerViewExpandableItemManager;
-import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractDraggableItemViewHolder;
 import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractExpandableItemAdapter;
 import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractExpandableItemViewHolder;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -51,7 +46,7 @@ public class MinimalExpandableExampleActivity extends AppCompatActivity {
         RecyclerView recyclerView = (RecyclerView) findViewById(R.id.recycler_view);
 
         // Setup expandable feature and RecyclerView
-        RecyclerViewExpandableItemManager expMgr = new RecyclerViewExpandableItemManager(null);
+        RecyclerViewExpandableItemManager expMgr = new RecyclerViewExpandableItemManager();
 
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
         recyclerView.setAdapter(expMgr.createWrappedAdapter(new MyAdapter()));

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleFragment.java
@@ -73,9 +73,12 @@ public class ExpandableDraggableWithSectionExampleFragment extends Fragment
         mLayoutManager = new LinearLayoutManager(getContext());
 
         final Parcelable eimSavedState = (savedInstanceState != null) ? savedInstanceState.getParcelable(SAVED_STATE_EXPANDABLE_ITEM_MANAGER) : null;
-        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
+        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager();
         mRecyclerViewExpandableItemManager.setOnGroupExpandListener(this);
         mRecyclerViewExpandableItemManager.setOnGroupCollapseListener(this);
+
+        // state must be set after listeners are added
+        mRecyclerViewExpandableItemManager.setSavedState(eimSavedState);
 
         // touch guard manager  (this class is required to suppress scrolling while swipe-dismiss animation is running)
         mRecyclerViewTouchActionGuardManager = new RecyclerViewTouchActionGuardManager();

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleFragment.java
@@ -73,9 +73,12 @@ public class ExpandableDraggableSwipeableExampleFragment extends Fragment
         mLayoutManager = new LinearLayoutManager(getContext());
 
         final Parcelable eimSavedState = (savedInstanceState != null) ? savedInstanceState.getParcelable(SAVED_STATE_EXPANDABLE_ITEM_MANAGER) : null;
-        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager(eimSavedState);
+        mRecyclerViewExpandableItemManager = new RecyclerViewExpandableItemManager();
         mRecyclerViewExpandableItemManager.setOnGroupExpandListener(this);
         mRecyclerViewExpandableItemManager.setOnGroupCollapseListener(this);
+
+        // state must be set after listeners are added
+        mRecyclerViewExpandableItemManager.setSavedState(eimSavedState);
 
         // touch guard manager  (this class is required to suppress scrolling while swipe-dismiss animation is running)
         mRecyclerViewTouchActionGuardManager = new RecyclerViewTouchActionGuardManager();

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
@@ -85,10 +85,8 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
 
     /**
      * Constructor.
-     *
-     * @param savedState The saved state object which is obtained from the {@link #getSavedState()} method.
      */
-    public RecyclerViewExpandableItemManager(@Nullable Parcelable savedState) {
+    public RecyclerViewExpandableItemManager() {
         mInternalUseOnItemTouchListener = new RecyclerView.OnItemTouchListener() {
             @Override
             public boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {
@@ -103,10 +101,6 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
             public void onRequestDisallowInterceptTouchEvent(boolean disallowIntercept) {
             }
         };
-
-        if (savedState instanceof SavedState) {
-            mSavedState = (SavedState) savedState;
-        }
     }
 
     /**
@@ -200,6 +194,18 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
         }
 
         return new SavedState(adapterSavedState);
+    }
+
+    /**
+     * <p>Sets saved state object in order to restore the internal state.</p>
+     * <p>Call this method after you have set expand and collapse listeners.</p>
+     *
+     * @param savedState The Parcelable object which stores information need to restore the internal states.
+     */
+    public void setSavedState(@Nullable Parcelable savedState){
+        if (savedState instanceof SavedState) {
+            mSavedState = (SavedState) savedState;
+        }
     }
 
     /*package*/ boolean onInterceptTouchEvent(RecyclerView rv, MotionEvent e) {


### PR DESCRIPTION
Do not pass in the state as part of the constructor for
`RecyclerViewExpandableItemManager`. The state relies on the expand and
collapse listeners to be set, and during the object construction these
listeners are null. Instead allow users to set the state after all
listeners have been set.

With current implementation, a state can never be set.  There is no `setState()` method, and the listeners will always be `null` during constructor method.