### PR TITLE
Improve not to cancel swiping on notifyItem* method called (#274)

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
@@ -522,9 +522,9 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
 
         final int swipeDistanceX = mLastTouchX - mTouchedItemOffsetX;
         final int swipeDistanceY = mLastTouchY - mTouchedItemOffsetY;
-        mSwipingItemPosition = getItemPosition(mAdapter, mSwipingItemId, mSwipingItemPosition);
+        final int swipingItemPosition = getSwipingItemPosition();
 
-        mSwipingItemOperator.update(mSwipingItemPosition, swipeDistanceX, swipeDistanceY);
+        mSwipingItemOperator.update(swipingItemPosition, swipeDistanceX, swipeDistanceY);
     }
 
     private boolean checkConditionAndStartSwiping(MotionEvent e, RecyclerView.ViewHolder holder) {
@@ -589,7 +589,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
             mRecyclerView.getParent().requestDisallowInterceptTouchEvent(false);
         }
 
-        final int itemPosition = getItemPosition(mAdapter, mSwipingItemId, mSwipingItemPosition);
+        final int itemPosition = getSwipingItemPosition();
 
         mVelocityTracker.clear();
 
@@ -687,7 +687,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
                 case RESULT_SWIPED_DOWN:
                     break;
                 default:
-                    throw new IllegalStateException("Unexpected after reaction has been requested: result = " + result +", afterReaction = " + afterReaction);
+                    throw new IllegalStateException("Unexpected after reaction has been requested: result = " + result + ", afterReaction = " + afterReaction);
             }
         }
     }
@@ -708,7 +708,8 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         }
     }
 
-    private static int getItemPosition(@Nullable RecyclerView.Adapter adapter, long itemId, int itemPositionGuess) {
+    /*package*/
+    static int getItemPosition(@Nullable RecyclerView.Adapter adapter, long itemId, int itemPositionGuess) {
         if (adapter == null)
             return RecyclerView.NO_POSITION;
 
@@ -718,7 +719,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
                 return itemPositionGuess;
         }
 
-        for (int i=0; i < itemCount; i++) {
+        for (int i = 0; i < itemCount; i++) {
             if (adapter.getItemId(i) == itemId)
                 return i;
         }
@@ -803,7 +804,8 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
      *
      * @return The listener object
      */
-    public @Nullable OnItemSwipeEventListener getOnItemSwipeEventListener() {
+    @Nullable
+    public OnItemSwipeEventListener getOnItemSwipeEventListener() {
         return mItemSwipeEventListener;
     }
 
@@ -889,6 +891,19 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         if (holder != null) {
             checkConditionAndStartSwiping(e, holder);
         }
+    }
+
+    /*package*/ int getSwipingItemPosition() {
+        return mSwipingItemPosition;
+    }
+
+    /*package*/ int syncSwipingItemPosition() {
+        return syncSwipingItemPosition(mSwipingItemPosition);
+    }
+
+    /*package*/ int syncSwipingItemPosition(int positionGuess) {
+        mSwipingItemPosition = getItemPosition(mAdapter, mSwipingItemId, positionGuess);
+        return mSwipingItemPosition;
     }
 
     private static boolean supportsViewPropertyAnimator() {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
@@ -151,45 +151,50 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
     protected void onHandleWrappedAdapterChanged() {
         if (isSwiping()) {
             cancelSwipe();
-        } else {
-            super.onHandleWrappedAdapterChanged();
         }
+        super.onHandleWrappedAdapterChanged();
     }
 
     @Override
     protected void onHandleWrappedAdapterItemRangeChanged(int positionStart, int itemCount) {
-        if (isSwiping()) {
-            cancelSwipe();
-        } else {
-            super.onHandleWrappedAdapterItemRangeChanged(positionStart, itemCount);
-        }
+        super.onHandleWrappedAdapterItemRangeChanged(positionStart, itemCount);
+    }
+
+    @Override
+    protected void onHandleWrappedAdapterItemRangeChanged(int positionStart, int itemCount, Object payload) {
+        super.onHandleWrappedAdapterItemRangeChanged(positionStart, itemCount, payload);
     }
 
     @Override
     protected void onHandleWrappedAdapterItemRangeInserted(int positionStart, int itemCount) {
         if (isSwiping()) {
-            cancelSwipe();
-        } else {
-            super.onHandleWrappedAdapterItemRangeInserted(positionStart, itemCount);
+            int pos = mSwipeManager.getSwipingItemPosition();
+            if (pos >= positionStart) {
+                mSwipeManager.syncSwipingItemPosition(pos + itemCount);
+            }
         }
+        super.onHandleWrappedAdapterItemRangeInserted(positionStart, itemCount);
     }
 
     @Override
     protected void onHandleWrappedAdapterItemRangeRemoved(int positionStart, int itemCount) {
         if (isSwiping()) {
-            cancelSwipe();
-        } else {
-            super.onHandleWrappedAdapterItemRangeRemoved(positionStart, itemCount);
+            int pos = mSwipeManager.getSwipingItemPosition();
+            if (checkInRange(pos, positionStart, itemCount)) {
+                cancelSwipe();
+            } else if (positionStart < pos) {
+                mSwipeManager.syncSwipingItemPosition(pos - itemCount);
+            }
         }
+        super.onHandleWrappedAdapterItemRangeRemoved(positionStart, itemCount);
     }
 
     @Override
     protected void onHandleWrappedAdapterRangeMoved(int fromPosition, int toPosition, int itemCount) {
         if (isSwiping()) {
-            cancelSwipe();
-        } else {
-            super.onHandleWrappedAdapterRangeMoved(fromPosition, toPosition, itemCount);
+            mSwipeManager.syncSwipingItemPosition();
         }
+        super.onHandleWrappedAdapterRangeMoved(fromPosition, toPosition, itemCount);
     }
 
     private void cancelSwipe() {
@@ -286,6 +291,10 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
 
     protected boolean isSwiping() {
         return (mSwipingItemId != RecyclerView.NO_ID);
+    }
+
+    private static boolean checkInRange(int pos, int start, int count) {
+        return (pos >= start) && (pos < (start + count));
     }
 
     private boolean swipeHorizontal() {


### PR DESCRIPTION
This PR fixes the issue #274. Not to cancel swiping on `notifyItem*` method called.