### PR TITLE
No need to set background for Button under swipeable example

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_button/SwipeableWithButtonExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_button/SwipeableWithButtonExampleAdapter.java
@@ -188,20 +188,6 @@ class SwipeableWithButtonExampleAdapter
 
     @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
-        int bgRes = 0;
-        switch (type) {
-            case Swipeable.DRAWABLE_SWIPE_NEUTRAL_BACKGROUND:
-                bgRes = R.drawable.bg_swipe_item_neutral;
-                break;
-            case Swipeable.DRAWABLE_SWIPE_LEFT_BACKGROUND:
-                bgRes = R.drawable.bg_swipe_item_left;
-                break;
-            case Swipeable.DRAWABLE_SWIPE_RIGHT_BACKGROUND:
-                bgRes = R.drawable.bg_swipe_item_right;
-                break;
-        }
-
-        holder.itemView.setBackgroundResource(bgRes);
     }
 
     @Override


### PR DESCRIPTION
Removed code to set background in onSetSwipeBackground for Button under swipeable item. bg_swipe_item_left was getting set after swipping but was not shown since another view complete redraw on it.
Notice redraws of bg_swipe_item_left which is not seen but still rendered under the button

![device-2016-12-19-214940](https://cloud.githubusercontent.com/assets/3098180/21320132/f802001c-c635-11e6-86a7-0a332118b89f.png)

After removing code which set background

![device-2016-12-19-215554](https://cloud.githubusercontent.com/assets/3098180/21320133/f80ae7d6-c635-11e6-8c69-70873924382b.png)
