### PR TITLE
fixed crash during dragging and swipe items and device rotation

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -2056,7 +2056,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         }
 
         public void release() {
-            removeCallbacks(null);
+            removeCallbacksAndMessages(null);
             mHolder = null;
         }
 

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
@@ -1006,7 +1006,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         }
 
         public void release() {
-            removeCallbacks(null);
+            removeCallbacksAndMessages(null);
             mHolder = null;
         }
 


### PR DESCRIPTION
1) Revert the line 2222 change
2) Change removeCallbacks(null) to removeCallbacksAndMessages(null)
IMPORTANT The same fault exists in the RecyclerViewSwipeManager, fix this too.
3) Confirm that the problem has been resolved.
4) Change the base branch of this PR to develop
