### PR TITLE
Feature/support get initial group expanded state method

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableItemAdapter.java
@@ -184,4 +184,13 @@ public interface ExpandableItemAdapter<GVH extends RecyclerView.ViewHolder, CVH 
      * @return Whether the group can be collapsed. If returns false, the group keeps expanded.
      */
     boolean onHookGroupCollapse(int groupPosition, boolean fromUser);
+
+    /**
+     * Gets initial expanded state of the group item. This method is called when initially creating
+     * a wrapper adapter and also when the data set is changed.
+     *
+     * @param groupPosition The position of the group
+     * @return True for expanded, otherwise false.
+     */
+    boolean getInitialGroupExpandedState(int groupPosition);
 }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
@@ -62,7 +62,7 @@ class ExpandablePositionTranslator {
         final int[] ids = mCachedGroupId;
         int expandedGroupCount = 0;
         int expandedChildCount = 0;
-        int totalChildCount = 0;
+
         for (int i = 0; i < groupCount; i++) {
             final long groupId = adapter.getGroupId(i);
             final int childCount = adapter.getChildCount(i);
@@ -77,14 +77,8 @@ class ExpandablePositionTranslator {
                 expanded = defaultExpandedState || adapter.getInitialGroupExpandedState(i);
             }
 
-            if (expanded) {
-                info[i] = (((long) (i + totalChildCount) << 32) | childCount) | FLAG_EXPANDED;
-            } else {
-                info[i] = (((long) i << 32) | childCount);
-            }
+            info[i] = (((long) (i + expandedChildCount) << 32) | childCount) | (expanded ? FLAG_EXPANDED : 0);
             ids[i] = (int) (groupId & LOWER_32BIT_MASK);
-
-            totalChildCount += childCount;
 
             if (expanded) {
                 expandedGroupCount += 1;

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
@@ -75,7 +75,10 @@ class ExpandableRecyclerViewWrapperAdapter
         mExpandableListManager = manager;
 
         mPositionTranslator = new ExpandablePositionTranslator();
-        mPositionTranslator.build(mExpandableItemAdapter, mExpandableListManager.getDefaultGroupsExpandedState());
+        mPositionTranslator.build(
+                mExpandableItemAdapter,
+                ExpandablePositionTranslator.BUILD_OPTION_DEFAULT,
+                mExpandableListManager.getDefaultGroupsExpandedState());
 
         if (expandedItemsSavedState != null) {
             // NOTE: do not call hook routines and listener methods
@@ -206,7 +209,10 @@ class ExpandableRecyclerViewWrapperAdapter
     private void rebuildPositionTranslator() {
         if (mPositionTranslator != null) {
             long[] savedState = mPositionTranslator.getSavedStateArray();
-            mPositionTranslator.build(mExpandableItemAdapter, mExpandableListManager.getDefaultGroupsExpandedState());
+            mPositionTranslator.build(
+                    mExpandableItemAdapter,
+                    ExpandablePositionTranslator.BUILD_OPTION_DEFAULT,
+                    mExpandableListManager.getDefaultGroupsExpandedState());
 
             // NOTE: do not call hook routines and listener methods
             mPositionTranslator.restoreExpandedGroupItems(savedState, null, null, null);
@@ -701,14 +707,20 @@ class ExpandableRecyclerViewWrapperAdapter
 
     /*package*/ void expandAll() {
         if (!mPositionTranslator.isEmpty() && !mPositionTranslator.isAllExpanded()) {
-            mPositionTranslator.build(mExpandableItemAdapter, true);
+            mPositionTranslator.build(
+                    mExpandableItemAdapter,
+                    ExpandablePositionTranslator.BUILD_OPTION_EXPANDED_ALL,
+                    mExpandableListManager.getDefaultGroupsExpandedState());
             notifyDataSetChanged();
         }
     }
 
     /*package*/ void collapseAll() {
         if (!mPositionTranslator.isEmpty() && !mPositionTranslator.isAllCollapsed()) {
-            mPositionTranslator.build(mExpandableItemAdapter, false);
+            mPositionTranslator.build(
+                    mExpandableItemAdapter,
+                    ExpandablePositionTranslator.BUILD_OPTION_COLLAPSED_ALL,
+                    mExpandableListManager.getDefaultGroupsExpandedState());
             notifyDataSetChanged();
         }
     }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/AbstractExpandableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/AbstractExpandableItemAdapter.java
@@ -137,4 +137,12 @@ public abstract class AbstractExpandableItemAdapter<GVH extends RecyclerView.Vie
     public boolean onHookGroupCollapse(int groupPosition, boolean fromUser) {
         return true;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean getInitialGroupExpandedState(int groupPosition) {
+        return false;
+    }
 }


### PR DESCRIPTION
This PR adds the `AbstractExpandableItemAdapter.getInitialGroupExpandedState()` method. It control the initial state of group items.