### PR TITLE
[BREAKING CHANGE] Add "payload" parameter to expandGroup() and collap…

### DIFF
--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_add_remove/AddRemoveExpandableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_add_remove/AddRemoveExpandableExampleFragment.java
@@ -164,11 +164,11 @@ public class AddRemoveExpandableExampleFragment
     }
 
     @Override
-    public void onGroupCollapse(int groupPosition, boolean fromUser) {
+    public void onGroupCollapse(int groupPosition, boolean fromUser, Object payload) {
     }
 
     @Override
-    public void onGroupExpand(int groupPosition, boolean fromUser) {
+    public void onGroupExpand(int groupPosition, boolean fromUser, Object payload) {
         // NOTE: fromUser is false because explicitly calling the
         // RecyclerViewExpandableItemManager.expand() method in adapter
         adjustScrollPositionOnGroupExpanded(groupPosition);

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_basic/ExpandableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_basic/ExpandableExampleFragment.java
@@ -134,11 +134,11 @@ public class ExpandableExampleFragment
     }
 
     @Override
-    public void onGroupCollapse(int groupPosition, boolean fromUser) {
+    public void onGroupCollapse(int groupPosition, boolean fromUser, Object payload) {
     }
 
     @Override
-    public void onGroupExpand(int groupPosition, boolean fromUser) {
+    public void onGroupExpand(int groupPosition, boolean fromUser, Object payload) {
         if (fromUser) {
             adjustScrollPositionOnGroupExpanded(groupPosition);
         }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleFragment.java
@@ -185,11 +185,11 @@ public class ExpandableDraggableWithSectionExampleFragment extends Fragment
     }
 
     @Override
-    public void onGroupCollapse(int groupPosition, boolean fromUser) {
+    public void onGroupCollapse(int groupPosition, boolean fromUser, Object payload) {
     }
 
     @Override
-    public void onGroupExpand(int groupPosition, boolean fromUser) {
+    public void onGroupExpand(int groupPosition, boolean fromUser, Object payload) {
         if (fromUser) {
             adjustScrollPositionOnGroupExpanded(groupPosition);
         }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleFragment.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleFragment.java
@@ -211,11 +211,11 @@ public class ExpandableDraggableSwipeableExampleFragment extends Fragment
     }
 
     @Override
-    public void onGroupCollapse(int groupPosition, boolean fromUser) {
+    public void onGroupCollapse(int groupPosition, boolean fromUser, Object payload) {
     }
 
     @Override
-    public void onGroupExpand(int groupPosition, boolean fromUser) {
+    public void onGroupExpand(int groupPosition, boolean fromUser, Object payload) {
         if (fromUser) {
             adjustScrollPositionOnGroupExpanded(groupPosition);
         }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableItemAdapter.java
@@ -177,6 +177,17 @@ public interface ExpandableItemAdapter<GVH extends RecyclerView.ViewHolder, CVH 
 
     /**
      * Called when a group attempt to expand by user operation or by
+     * {@link com.h6ah4i.android.widget.advrecyclerview.expandable.RecyclerViewExpandableItemManager#expandGroup(int)} method.
+     *
+     * @param groupPosition The position of the group item within the adapter's data set
+     * @param fromUser      Whether the expand request is issued by a user operation
+     * @param payload       Optional parameter, use null to identify a "full" update the group item
+     * @return Whether the group can be expanded. If returns false, the group keeps collapsed.
+     */
+    boolean onHookGroupExpand(int groupPosition, boolean fromUser, Object payload);
+
+    /**
+     * Called when a group attempt to expand by user operation or by
      * {@link com.h6ah4i.android.widget.advrecyclerview.expandable.RecyclerViewExpandableItemManager#collapseGroup(int)} method.
      *
      * @param groupPosition The position of the group item within the adapter's data set
@@ -184,4 +195,15 @@ public interface ExpandableItemAdapter<GVH extends RecyclerView.ViewHolder, CVH 
      * @return Whether the group can be collapsed. If returns false, the group keeps expanded.
      */
     boolean onHookGroupCollapse(int groupPosition, boolean fromUser);
+
+    /**
+     * Called when a group attempt to expand by user operation or by
+     * {@link com.h6ah4i.android.widget.advrecyclerview.expandable.RecyclerViewExpandableItemManager#collapseGroup(int)} method.
+     *
+     * @param groupPosition The position of the group item within the adapter's data set
+     * @param fromUser      Whether the collapse request is issued by a user operation
+     * @param payload       Optional parameter, use null to identify a "full" update the group item
+     * @return Whether the group can be collapsed. If returns false, the group keeps expanded.
+     */
+    boolean onHookGroupCollapse(int groupPosition, boolean fromUser, Object payload);
 }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandablePositionTranslator.java
@@ -121,18 +121,18 @@ class ExpandablePositionTranslator {
                     index = j + 1;
 
                     if (expanded) {
-                        if (adapter == null || adapter.onHookGroupExpand(position, fromUser)) {
+                        if (adapter == null || adapter.onHookGroupExpand(position, fromUser, null)) {
                             if (expandGroup(position)) {
                                 if (expandListener != null) {
-                                    expandListener.onGroupExpand(position, fromUser);
+                                    expandListener.onGroupExpand(position, fromUser, null);
                                 }
                             }
                         }
                     } else {
-                        if (adapter == null || adapter.onHookGroupCollapse(position, fromUser)) {
+                        if (adapter == null || adapter.onHookGroupCollapse(position, fromUser, null)) {
                             if (collapseGroup(position)) {
                                 if (collapseListener != null) {
-                                    collapseListener.onGroupCollapse(position, fromUser);
+                                    collapseListener.onGroupCollapse(position, fromUser, null);
                                 }
                             }
                         }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
@@ -691,9 +691,9 @@ class ExpandableRecyclerViewWrapperAdapter
         }
 
         if (expand) {
-            expandGroup(groupPosition, true);
+            expandGroup(groupPosition, true, null);
         } else {
-            collapseGroup(groupPosition, true);
+            collapseGroup(groupPosition, true, null);
         }
 
         return true;
@@ -713,13 +713,13 @@ class ExpandableRecyclerViewWrapperAdapter
         }
     }
 
-    /*package*/ boolean collapseGroup(int groupPosition, boolean fromUser) {
+    /*package*/ boolean collapseGroup(int groupPosition, boolean fromUser, Object payload) {
         if (!mPositionTranslator.isGroupExpanded(groupPosition)) {
             return false;
         }
 
         // call hook method
-        if (!mExpandableItemAdapter.onHookGroupCollapse(groupPosition, fromUser)) {
+        if (!mExpandableItemAdapter.onHookGroupCollapse(groupPosition, fromUser, payload)) {
             return false;
         }
 
@@ -736,24 +736,24 @@ class ExpandableRecyclerViewWrapperAdapter
             final long packedPosition = ExpandableAdapterHelper.getPackedPositionForGroup(groupPosition);
             final int flatPosition = mPositionTranslator.getFlatPosition(packedPosition);
 
-            notifyItemChanged(flatPosition);
+            notifyItemChanged(flatPosition, payload);
         }
 
         // raise onGroupCollapse() event
         if (mOnGroupCollapseListener != null) {
-            mOnGroupCollapseListener.onGroupCollapse(groupPosition, fromUser);
+            mOnGroupCollapseListener.onGroupCollapse(groupPosition, fromUser, payload);
         }
 
         return true;
     }
 
-    /*package*/ boolean expandGroup(int groupPosition, boolean fromUser) {
+    /*package*/ boolean expandGroup(int groupPosition, boolean fromUser, Object payload) {
         if (mPositionTranslator.isGroupExpanded(groupPosition)) {
             return false;
         }
 
         // call hook method
-        if (!mExpandableItemAdapter.onHookGroupExpand(groupPosition, fromUser)) {
+        if (!mExpandableItemAdapter.onHookGroupExpand(groupPosition, fromUser, payload)) {
             return false;
         }
 
@@ -769,12 +769,12 @@ class ExpandableRecyclerViewWrapperAdapter
             final long packedPosition = ExpandableAdapterHelper.getPackedPositionForGroup(groupPosition);
             final int flatPosition = mPositionTranslator.getFlatPosition(packedPosition);
 
-            notifyItemChanged(flatPosition);
+            notifyItemChanged(flatPosition, payload);
         }
 
         // raise onGroupExpand() event
         if (mOnGroupExpandListener != null) {
-            mOnGroupExpandListener.onGroupExpand(groupPosition, fromUser);
+            mOnGroupExpandListener.onGroupExpand(groupPosition, fromUser, payload);
         }
 
         return true;
@@ -923,7 +923,7 @@ class ExpandableRecyclerViewWrapperAdapter
             notifyItemInserted(flatPosition);
 
             // raise onGroupExpand() event
-            raiseOnGroupExpandedSequentially(groupPosition, 1, false);
+            raiseOnGroupExpandedSequentially(groupPosition, 1, false, null);
         }
     }
 
@@ -935,7 +935,7 @@ class ExpandableRecyclerViewWrapperAdapter
 
             notifyItemRangeInserted(flatPosition, insertedCount);
 
-            raiseOnGroupExpandedSequentially(groupPositionStart, count, false);
+            raiseOnGroupExpandedSequentially(groupPositionStart, count, false, null);
         }
     }
 
@@ -977,10 +977,10 @@ class ExpandableRecyclerViewWrapperAdapter
         }
     }
 
-    private void raiseOnGroupExpandedSequentially(int groupPositionStart, int count, boolean fromUser) {
+    private void raiseOnGroupExpandedSequentially(int groupPositionStart, int count, boolean fromUser, Object payload) {
         if (mOnGroupExpandListener != null) {
             for (int i = 0; i < count; i++) {
-                mOnGroupExpandListener.onGroupExpand(groupPositionStart + i, fromUser);
+                mOnGroupExpandListener.onGroupExpand(groupPositionStart + i, fromUser, payload);
             }
         }
     }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/RecyclerViewExpandableItemManager.java
@@ -56,8 +56,9 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
          *
          * @param groupPosition The group position that was expanded
          * @param fromUser      Whether the expand request is issued by a user operation
+         * @param payload       Optional parameter, use null to identify a "full" update of the group item
          */
-        void onGroupExpand(int groupPosition, boolean fromUser);
+        void onGroupExpand(int groupPosition, boolean fromUser, Object payload);
     }
 
     /**
@@ -69,8 +70,9 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
          *
          * @param groupPosition The group position that was collapsed
          * @param fromUser      Whether the collapse request is issued by a user operation
+         * @param payload       Optional parameter, use null to identify a "full" update of the group item
          */
-        void onGroupCollapse(int groupPosition, boolean fromUser);
+        void onGroupCollapse(int groupPosition, boolean fromUser, Object payload);
     }
 
     // ---
@@ -297,7 +299,7 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
 
     /**
      * <p>Expand all groups.</p>
-     * <p>Note that this method does not invoke the {@link OnGroupExpandListener#onGroupExpand(int, boolean)} callback.</p>
+     * <p>Note that this method does not invoke the {@link OnGroupExpandListener#onGroupExpand(int, boolean, Object)} callback.</p>
      */
     public void expandAll() {
         if (mWrapperAdapter != null) {
@@ -307,7 +309,7 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
 
     /**
      * <p>Collapse all groups.</p>
-     * <p>Note that this method does not invoke the {@link OnGroupCollapseListener#onGroupCollapse(int, boolean)} callback.</p>
+     * <p>Note that this method does not invoke the {@link OnGroupCollapseListener#onGroupCollapse(int, boolean, Object)} callback.</p>
      */
     public void collapseAll() {
         if (mWrapperAdapter != null) {
@@ -322,7 +324,18 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
      * @return True if the group was expanded, false otherwise  (If the group was already expanded, this will return false)
      */
     public boolean expandGroup(int groupPosition) {
-        return (mWrapperAdapter != null) && mWrapperAdapter.expandGroup(groupPosition, false);
+        return expandGroup(groupPosition, null);
+    }
+
+    /**
+     * Expand a group.
+     *
+     * @param groupPosition The group position to be expanded
+     * @param payload Optional parameter, use null to identify a "full" update the group item
+     * @return True if the group was expanded, false otherwise  (If the group was already expanded, this will return false)
+     */
+    public boolean expandGroup(int groupPosition, Object payload) {
+        return (mWrapperAdapter != null) && mWrapperAdapter.expandGroup(groupPosition, false, payload);
     }
 
     /**
@@ -332,7 +345,18 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
      * @return True if the group was collapsed, false otherwise  (If the group was already collapsed, this will return false)
      */
     public boolean collapseGroup(int groupPosition) {
-        return (mWrapperAdapter != null) && mWrapperAdapter.collapseGroup(groupPosition, false);
+        return collapseGroup(groupPosition, null);
+    }
+
+    /**
+     * Collapse a group.
+     *
+     * @param groupPosition The group position to be collapsed
+     * @param payload Optional parameter, use null to identify a "full" update the group item
+     * @return True if the group was collapsed, false otherwise  (If the group was already collapsed, this will return false)
+     */
+    public boolean collapseGroup(int groupPosition, Object payload) {
+        return (mWrapperAdapter != null) && mWrapperAdapter.collapseGroup(groupPosition, false, payload);
     }
 
     /**
@@ -551,8 +575,8 @@ public class RecyclerViewExpandableItemManager implements ExpandableItemConstant
      *
      * @param savedState    The saved state object
      * @param callHooks     Whether to call hook routines
-     *                      ({@link ExpandableItemAdapter#onHookGroupExpand(int, boolean)},
-     *                      {@link ExpandableItemAdapter#onHookGroupCollapse(int, boolean)})
+     *                      ({@link ExpandableItemAdapter#onHookGroupExpand(int, boolean, Object)},
+     *                      {@link ExpandableItemAdapter#onHookGroupCollapse(int, boolean, Object)})
      * @param callListeners Whether to invoke {@link OnGroupExpandListener} and/or {@link OnGroupCollapseListener} listener events
      */
     public void restoreState(@Nullable Parcelable savedState, boolean callHooks, boolean callListeners) {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/AbstractExpandableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/utils/AbstractExpandableItemAdapter.java
@@ -134,7 +134,25 @@ public abstract class AbstractExpandableItemAdapter<GVH extends RecyclerView.Vie
      * {@inheritDoc}
      */
     @Override
+    public boolean onHookGroupExpand(int groupPosition, boolean fromUser, Object payload) {
+        return onHookGroupExpand(groupPosition, fromUser);
+    }
+
+    /**
+     * Override this method if need to customize the behavior.
+     * {@inheritDoc}
+     */
+    @Override
     public boolean onHookGroupCollapse(int groupPosition, boolean fromUser) {
         return true;
+    }
+
+    /**
+     * Override this method if need to customize the behavior.
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean onHookGroupCollapse(int groupPosition, boolean fromUser, Object payload) {
+        return onHookGroupCollapse(groupPosition, fromUser);
     }
 }


### PR DESCRIPTION
…seGroup()  (#350)

This commit also changes OnGroupExpandListener and OnCollapseExpandListener.
These two listeners now have the payload parameter and it's a breaking syntax change.