### PR TITLE
Expose path segments for header footer adapter

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/headerfooter/AbstractHeaderFooterWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/headerfooter/AbstractHeaderFooterWrapperAdapter.java
@@ -80,9 +80,9 @@ public abstract class AbstractHeaderFooterWrapperAdapter<HeaderVH extends Recycl
         mFooterAdapter.setHasStableIds(hasStableIds);
         setHasStableIds(hasStableIds);
 
-        addAdapter(mHeaderAdapter);
-        addAdapter(mWrappedAdapter);
-        addAdapter(mFooterAdapter);
+        mHeaderAdapterTag = addAdapter(mHeaderAdapter);
+        mWrappedAdapterTag = addAdapter(mWrappedAdapter);
+        mFooterAdapterTag = addAdapter(mFooterAdapter);
 
         return this;
     }
@@ -143,6 +143,34 @@ public abstract class AbstractHeaderFooterWrapperAdapter<HeaderVH extends Recycl
      */
     public RecyclerView.Adapter getWrappedAdapter() {
         return mWrappedAdapter;
+    }
+
+
+    /**
+     * Returns the path segment for the underlying adapter.
+     *
+     * @return AdapterPathSegment for the wrapped adapter
+     */
+    public AdapterPathSegment getWrappedAdapterSegment() {
+      return new AdapterPathSegment(mWrappedAdapter, mWrappedAdapterTag);
+    }
+
+    /**
+     * Returns the path segment for the header adapter.
+     *
+     * @return AdapterPathSegment for the header adapter
+     */
+    public AdapterPathSegment getHeaderSegment() {
+      return new AdapterPathSegment(mHeaderAdapter, mHeaderAdapterTag);
+    }
+
+    /**
+     * Returns the path segment for the footer adapter.
+     *
+     * @return AdapterPathSegment for the footer adapter
+     */
+    public AdapterPathSegment getFooterSegment() {
+      return new AdapterPathSegment(mFooterAdapter, mFooterAdapterTag);
     }
 
     /**


### PR DESCRIPTION
The tag fields already existed, but were never assigned.
This is needed to wrap the position for a segment.