### PR TITLE
Fix onViewRecycled() method not invoked issue (#376)

### DIFF
--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
@@ -287,13 +287,13 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
     }
 
     @Override
-    public void onViewRecycled(VH holder) {
+    public void onViewRecycled(VH holder, int viewType) {
         if (isDragging()) {
             mDragDropManager.onItemViewRecycled(holder);
             mDraggingItemViewHolder = mDragDropManager.getDraggingItemViewHolder();
         }
 
-        super.onViewRecycled(holder);
+        super.onViewRecycled(holder, viewType);
     }
 
     // NOTE: This method is called from RecyclerViewDragDropManager

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
@@ -220,12 +220,12 @@ class ExpandableRecyclerViewWrapperAdapter
     }
 
     @Override
-    public void onViewRecycled(RecyclerView.ViewHolder holder) {
+    public void onViewRecycled(RecyclerView.ViewHolder holder, int viewType) {
         if (holder instanceof ExpandableItemViewHolder) {
             ((ExpandableItemViewHolder) holder).setExpandStateFlags(STATE_FLAG_INITIAL_VALUE);
         }
 
-        super.onViewRecycled(holder);
+        super.onViewRecycled(holder, viewType);
     }
 
     @Override

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
@@ -68,8 +68,8 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
     }
 
     @Override
-    public void onViewRecycled(VH holder) {
-        super.onViewRecycled(holder);
+    public void onViewRecycled(VH holder, int viewType) {
+        super.onViewRecycled(holder, viewType);
 
         if ((mSwipingItemId != RecyclerView.NO_ID) && (mSwipingItemId == holder.getItemId())) {
             mSwipeManager.cancelSwipe();


### PR DESCRIPTION
Fixes #376. The `onViewRecycled(RecyclerView.ViewHolder vh)` method is not called anymore for `WrapperAdapter` so they are changed to `onViewRecycled(RecyclerView.ViewHolder vh, int viewType)`.