### PR TITLE
[BREAKING CHANGE] Add onItemSwipeStarted() method to SwipeableItemAdapter (#400)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Latest version
 
 **Recent Breaking Change Info**
 
-- **v0.11.0:**  Since official support libraries have dropped support older API levels than v14, this library does also dropped support them since v0.11.0. If you still need to support API level v9, please continue to use v0.10.6.
+- **v0.11.0:**
+  - Since official support libraries have dropped support older API levels than v14, this library does also dropped support them since v0.11.0. If you still need to support API level v9, please continue to use v0.10.6.
+  - A new callback `onItemSwipeStarted()` is added to `SwipeableItemAdapter`. Users must invoke appropriate `notify*()` method in this method.
 
 - **v0.10.4:** `OnGroupExpandListener` and `OnGroupCollapseListener` takes `payload` parameter. (related: [issue #350](https://github.com/h6ah4i/android-advancedrecyclerview/issues/350))
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_composition_all/MySwipeableAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_composition_all/MySwipeableAdapter.java
@@ -110,6 +110,11 @@ class MySwipeableAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public SwipeResultAction onSwipeItem(MyViewHolder holder, int position, @SwipeableItemResults int result) {
         if (result == Swipeable.RESULT_CANCELED) {
             return new SwipeResultActionDefault();

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
@@ -228,6 +228,11 @@ class DraggableSwipeableExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
         int bgRes = 0;
         switch (type) {

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
@@ -399,6 +399,16 @@ class ExpandableDraggableSwipeableExampleAdapter
     }
 
     @Override
+    public void onSwipeGroupItemStarted(MyGroupViewHolder holder, int groupPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onSwipeChildItemStarted(MyChildViewHolder holder, int groupPosition, int childPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetGroupItemSwipeBackground(MyGroupViewHolder holder, int groupPosition, int type) {
         int bgResId = 0;
         switch (type) {

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_basic/SwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_basic/SwipeableExampleAdapter.java
@@ -163,6 +163,11 @@ class SwipeableExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public int onGetSwipeReactionType(MyViewHolder holder, int position, int x, int y) {
         return Swipeable.REACTION_CAN_SWIPE_BOTH_H;
     }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_button/SwipeableWithButtonExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_button/SwipeableWithButtonExampleAdapter.java
@@ -190,6 +190,11 @@ class SwipeableWithButtonExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
         if (type == Swipeable.DRAWABLE_SWIPE_NEUTRAL_BACKGROUND) {
             holder.mBehindViews.setVisibility(View.GONE);

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_longpress/SwipeOnLongPressExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_longpress/SwipeOnLongPressExampleAdapter.java
@@ -170,6 +170,11 @@ class SwipeOnLongPressExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
         int bgRes = 0;
         switch (type) {

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_minimal/MinimalSwipeableExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_minimal/MinimalSwipeableExampleActivity.java
@@ -127,6 +127,11 @@ public class MinimalSwipeableExampleActivity extends AppCompatActivity {
         }
 
         @Override
+        public void onSwipeItemStarted(MyViewHolder holder, int position) {
+            notifyDataSetChanged();
+        }
+
+        @Override
         public SwipeResultAction onSwipeItem(MyViewHolder holder, int position, @SwipeableItemResults int result) {
             if (result == Swipeable.RESULT_CANCELED) {
                 return new SwipeResultActionDefault();

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_vertical/VerticalSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_vertical/VerticalSwipeableExampleAdapter.java
@@ -164,6 +164,11 @@ class VerticalSwipeableExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
         int bgRes = 0;
         switch (type) {

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_viewpager/ViewPagerSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_s_viewpager/ViewPagerSwipeableExampleAdapter.java
@@ -131,6 +131,11 @@ class ViewPagerSwipeableExampleAdapter
     }
 
     @Override
+    public void onSwipeItemStarted(MyViewHolder holder, int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onSetSwipeBackground(MyViewHolder holder, int position, int type) {
         if (type == Swipeable.DRAWABLE_SWIPE_NEUTRAL_BACKGROUND) {
             holder.itemView.setBackgroundColor(Color.TRANSPARENT);

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
@@ -437,6 +437,18 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
         return swipeableItemAdapter.onGetSwipeReactionType(holder, correctedPosition, x, y);
     }
 
+    @Override
+    public void onSwipeItemStarted(VH holder, int position) {
+        RecyclerView.Adapter adapter = getWrappedAdapter();
+        if (!(adapter instanceof SwipeableItemAdapter)) {
+            return;
+        }
+
+        int correctedPosition = getOriginalPosition(position);
+
+        ((SwipeableItemAdapter) adapter).onSwipeItemStarted(holder, correctedPosition);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     public void onSetSwipeBackground(VH holder, int position, int type) {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/BaseExpandableSwipeableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/BaseExpandableSwipeableItemAdapter.java
@@ -74,6 +74,27 @@ public interface BaseExpandableSwipeableItemAdapter<GVH extends RecyclerView.Vie
     int onGetChildItemSwipeReactionType(CVH holder, int groupPosition, int childPosition, int x, int y);
 
     /**
+     * Called when started swiping a group item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param holder The ViewHolder that is associated the swiped item.
+     * @param groupPosition Group position.
+     */
+    void onSwipeGroupItemStarted(GVH holder, int groupPosition);
+
+    /**
+     * Called when started swiping a child item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param holder The ViewHolder that is associated the swiped item.
+     * @param groupPosition Group position.
+     * @param childPosition Child position.
+     */
+    void onSwipeChildItemStarted(CVH holder, int groupPosition, int childPosition);
+
+    /**
      * Called when sets background of the swiping group item.
      *
      * @param holder The ViewHolder which is associated to the swiping item.

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableRecyclerViewWrapperAdapter.java
@@ -628,6 +628,28 @@ class ExpandableRecyclerViewWrapperAdapter
 
     @SuppressWarnings("unchecked")
     @Override
+    public void onSwipeItemStarted(RecyclerView.ViewHolder holder, int position) {
+        if (!(mExpandableItemAdapter instanceof BaseExpandableSwipeableItemAdapter)) {
+            return;
+        }
+
+        final BaseExpandableSwipeableItemAdapter adapter = (BaseExpandableSwipeableItemAdapter) mExpandableItemAdapter;
+
+        //noinspection UnnecessaryLocalVariable
+        final int flatPosition = position;
+        final long expandablePosition = mPositionTranslator.getExpandablePosition(flatPosition);
+        final int groupPosition = ExpandableAdapterHelper.getPackedPositionGroup(expandablePosition);
+        final int childPosition = ExpandableAdapterHelper.getPackedPositionChild(expandablePosition);
+
+        if (childPosition == RecyclerView.NO_POSITION) {
+            adapter.onSwipeGroupItemStarted(holder, groupPosition);
+        } else {
+            adapter.onSwipeChildItemStarted(holder, groupPosition, childPosition);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public void onSetSwipeBackground(RecyclerView.ViewHolder holder, int position, int type) {
         if (!(mExpandableItemAdapter instanceof BaseExpandableSwipeableItemAdapter)) {
             return;

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/RecyclerViewSwipeManager.java
@@ -600,7 +600,7 @@ public class RecyclerViewSwipeManager implements SwipeableItemConstants {
         }
 
         // raise onSwipeItemStarted() event
-        mWrapperAdapter.onSwipeItemStarted(this, holder, mSwipingItemId);
+        mWrapperAdapter.onSwipeItemStarted(this, holder, itemPosition, mSwipingItemId);
     }
 
     private void finishSwiping(int result) {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemAdapter.java
@@ -26,7 +26,7 @@ import com.h6ah4i.android.widget.advrecyclerview.swipeable.annotation.SwipeableI
 public interface SwipeableItemAdapter<T extends RecyclerView.ViewHolder> {
 
     /**
-     * Called when user is attempt to swipe the item.
+     * Called when the user is attempt to swipe an item.
      *
      * @param holder The ViewHolder which is associated to item user is attempt to start swiping.
      * @param position The position of the item within the adapter's data set.
@@ -51,6 +51,16 @@ public interface SwipeableItemAdapter<T extends RecyclerView.ViewHolder> {
     int onGetSwipeReactionType(T holder, int position, int x, int y);
 
     /**
+     * Called when started swiping an item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param holder The ViewHolder that is associated the swiped item.
+     * @param position The position of the item within the adapter's data set.
+     */
+    void onSwipeItemStarted(T holder, int position);
+
+    /**
      * Called when sets background of the swiping item.
      *
      * @param holder The ViewHolder which is associated to the swiping item.
@@ -65,7 +75,7 @@ public interface SwipeableItemAdapter<T extends RecyclerView.ViewHolder> {
     void onSetSwipeBackground(T holder, int position, @SwipeableItemDrawableTypes int type);
 
     /**
-     * Called when item is swiped.
+     * Called when an item is swiped.
      *
      * *Note that do not change the data set and do not call notifyDataXXX() methods inside of this method.*
      *

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/swipeable/SwipeableItemWrapperAdapter.java
@@ -42,6 +42,7 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
     private SwipeableItemAdapter mSwipeableItemAdapter;
     private RecyclerViewSwipeManager mSwipeManager;
     private long mSwipingItemId = RecyclerView.NO_ID;
+    private boolean mCallingSwipeStarted;
 
     public SwipeableItemWrapperAdapter(RecyclerViewSwipeManager manager, RecyclerView.Adapter<VH> adapter) {
         super(adapter);
@@ -153,7 +154,7 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
 
     @Override
     protected void onHandleWrappedAdapterChanged() {
-        if (isSwiping()) {
+        if (isSwiping() && !mCallingSwipeStarted) {
             cancelSwipe();
         }
         super.onHandleWrappedAdapterChanged();
@@ -260,14 +261,16 @@ class SwipeableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Ba
     }
 
     // NOTE: This method is called from RecyclerViewSwipeManager
-    /*package*/ void onSwipeItemStarted(RecyclerViewSwipeManager manager, RecyclerView.ViewHolder holder, long id) {
+    /*package*/ void onSwipeItemStarted(RecyclerViewSwipeManager manager, RecyclerView.ViewHolder holder, int position, long id) {
         if (LOCAL_LOGD) {
-            Log.d(TAG, "onSwipeItemStarted(holder = " + holder + ", id = " + id + ")");
+            Log.d(TAG, "onSwipeItemStarted(holder = " + holder + ", position = " + position + ", id = " + id + ")");
         }
 
         mSwipingItemId = id;
 
-        notifyDataSetChanged();
+        mCallingSwipeStarted = true;
+        mSwipeableItemAdapter.onSwipeItemStarted(holder, position);
+        mCallingSwipeStarted = false;
     }
 
     // NOTE: This method is called from RecyclerViewSwipeManager


### PR DESCRIPTION
Introduce a new callback which is called when swiping is started. This new callback gives flexibility how invalidate list items on swiping.

---

**IMPORTANT**
A new callback method have been added to `SwipeableItemAdapter`. So please add this new onItemSwipeStarted() method to your adapter.

Inside the method, you can call notify*() method to invalidate items. Before this change, the library always calls the notifyDataSetChanged() method internally. If you need the same behavior, put a method call of notifyDataSetChanged() in the onItemSwipeStarted().

Related issues/pull requests
- Only notify adapter to change the item being swiped #395
- NotifyDataSetChanged caused recycleview to blink #232
- swipe not so smooth like examples #129