### PR TITLE
[BREAKING CHANGE] Add onItemDragStarted() / onItemDragFinished() callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Latest version
 - **v0.11.0:**
   - Since official support libraries have dropped support older API levels than v14, this library does also dropped support them since v0.11.0. If you still need to support API level v9, please continue to use v0.10.6.
   - A new callback `onItemSwipeStarted()` is added to `SwipeableItemAdapter`. Users must invoke appropriate `notify*()` method in this method.
+  - A new callback `onItemDragStarted()` is added to `DraggableItemAdapter`. Users must invoke appropriate `notify*()` method in this method.
+  - A new callback `onItemDragFinished()` is added to `DraggableItemAdapter`. Users must invoke appropriate `notify*()` method in this method.
 
 - **v0.10.4:** `OnGroupExpandListener` and `OnGroupCollapseListener` takes `payload` parameter. (related: [issue #350](https://github.com/h6ah4i/android-advancedrecyclerview/issues/350))
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_composition_all/MyDraggableAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_composition_all/MyDraggableAdapter.java
@@ -121,6 +121,16 @@ class MyDraggableAdapter
     }
 
     @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public void onClick(View v) {
         RecyclerView rv = RecyclerViewAdapterUtils.getParentRecyclerView(v);
         RecyclerView.ViewHolder vh = rv.findContainingViewHolder(v);

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_basic/DraggableExampleItemAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_basic/DraggableExampleItemAdapter.java
@@ -151,4 +151,14 @@ class DraggableExampleItemAdapter
     public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
         return true;
     }
+
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleItemAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_check_can_drop/DraggableCheckCanDropExampleItemAdapter.java
@@ -151,4 +151,14 @@ class DraggableCheckCanDropExampleItemAdapter
     public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
         return (draggingPosition % 2) == (dropPosition % 2);
     }
+
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/DraggableGridExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_grid/DraggableGridExampleAdapter.java
@@ -152,4 +152,14 @@ class DraggableGridExampleAdapter
     public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
         return true;
     }
+
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_minimal/MinimalDraggableExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_minimal/MinimalDraggableExampleActivity.java
@@ -137,5 +137,13 @@ public class MinimalDraggableExampleActivity extends AppCompatActivity {
         public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
             return true;
         }
+
+        @Override
+        public void onItemDragStarted(int position) {
+        }
+
+        @Override
+        public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        }
     }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/DragOnLongPressExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_on_longpress/DragOnLongPressExampleAdapter.java
@@ -151,4 +151,14 @@ class DragOnLongPressExampleAdapter
     public boolean onCheckCanDrop(int draggingPosition, int dropPosition) {
         return true;
     }
+
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
 }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_staggered_grid/DraggableStaggeredGridExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_staggered_grid/DraggableStaggeredGridExampleAdapter.java
@@ -216,6 +216,16 @@ class DraggableStaggeredGridExampleAdapter
         return true;
     }
 
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
     static int getHeaderItemCount() {
         return (USE_DUMMY_HEADER) ? 1 : 0;
     }

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_with_section/DraggableWithSectionExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_d_with_section/DraggableWithSectionExampleAdapter.java
@@ -196,6 +196,16 @@ class DraggableWithSectionExampleAdapter
         return true;
     }
 
+    @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
     private int findFirstSectionItem(int position) {
         AbstractDataProvider.Data item = mProvider.getItem(position);
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ds/DraggableSwipeableExampleAdapter.java
@@ -219,6 +219,16 @@ class DraggableSwipeableExampleAdapter
     }
 
     @Override
+    public void onItemDragStarted(int position) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onItemDragFinished(int fromPosition, int toPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public int onGetSwipeReactionType(MyViewHolder holder, int position, int x, int y) {
         if (onCheckCanStartDrag(holder, position, x, y)) {
             return Swipeable.REACTION_CAN_NOT_SWIPE_BOTH_H;

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_minimal/MinimalExpandableExampleActivity.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_e_minimal/MinimalExpandableExampleActivity.java
@@ -27,10 +27,7 @@ import android.view.ViewGroup;
 import android.widget.TextView;
 
 import com.h6ah4i.android.example.advrecyclerview.R;
-import com.h6ah4i.android.widget.advrecyclerview.draggable.DraggableItemAdapter;
-import com.h6ah4i.android.widget.advrecyclerview.draggable.ItemDraggableRange;
 import com.h6ah4i.android.widget.advrecyclerview.expandable.RecyclerViewExpandableItemManager;
-import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractDraggableItemViewHolder;
 import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractExpandableItemAdapter;
 import com.h6ah4i.android.widget.advrecyclerview.utils.AbstractExpandableItemViewHolder;
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_ed_with_section/ExpandableDraggableWithSectionExampleAdapter.java
@@ -369,6 +369,26 @@ class ExpandableDraggableWithSectionExampleAdapter
         mProvider.moveChildItem(fromGroupPosition, fromChildPosition, toGroupPosition, toChildPosition);
     }
 
+    @Override
+    public void onGroupDragStarted(int groupPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onChildDragStarted(int groupPosition, int childPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onGroupDragFinished(int fromGroupPosition, int toGroupPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onChildDragFinished(int fromGroupPosition, int fromChildPosition, int toGroupPosition, int toChildPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
     private int findFirstSectionItem(int position) {
         AbstractExpandableDataProvider.GroupData item = mProvider.getGroupItem(position);
 

--- a/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
+++ b/example/src/main/java/com/h6ah4i/android/example/advrecyclerview/demo_eds/ExpandableDraggableSwipeableExampleAdapter.java
@@ -381,6 +381,26 @@ class ExpandableDraggableSwipeableExampleAdapter
     }
 
     @Override
+    public void onGroupDragStarted(int groupPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onChildDragStarted(int groupPosition, int childPosition) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onGroupDragFinished(int fromGroupPosition, int toGroupPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
+    @Override
+    public void onChildDragFinished(int fromGroupPosition, int fromChildPosition, int toGroupPosition, int toChildPosition, boolean result) {
+        notifyDataSetChanged();
+    }
+
+    @Override
     public int onGetGroupItemSwipeReactionType(MyGroupViewHolder holder, int groupPosition, int x, int y) {
         if (onCheckGroupCanStartDrag(holder, groupPosition, x, y)) {
             return Swipeable.REACTION_CAN_NOT_SWIPE_BOTH_H;

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemAdapter.java
@@ -62,4 +62,24 @@ public interface DraggableItemAdapter<T extends RecyclerView.ViewHolder> {
      * @return Whether can be dropped to the specified position.
      */
     boolean onCheckCanDrop(int draggingPosition, int dropPosition);
+
+    /**
+     * Callback method to be invoked when started dragging an item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param position The position of the item.
+     */
+    void onItemDragStarted(int position);
+
+    /**
+     * Callback method to be invoked when finished dragging an item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param fromPosition Previous position of the item.
+     * @param toPosition   New position of the item.
+     * @param result       Indicates whether the dragging operation was succeeded.
+     */
+    void onItemDragFinished(int fromPosition, int toPosition, boolean result);
 }

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/DraggableItemWrapperAdapter.java
@@ -51,6 +51,7 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
     private int mDraggingItemInitialPosition = RecyclerView.NO_POSITION;
     private int mDraggingItemCurrentPosition = RecyclerView.NO_POSITION;
     private int mItemMoveMode;
+    private boolean mCallingDragStarted;
 
     public DraggableItemWrapperAdapter(RecyclerViewDragDropManager manager, RecyclerView.Adapter<VH> adapter) {
         super(adapter);
@@ -223,7 +224,7 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
         if (DEBUG_BYPASS_MOVE_OPERATION_MODE) {
             return false;
         }
-        return isDragging();
+        return isDragging() && !mCallingDragStarted;
     }
 
     private void cancelDrag() {
@@ -233,7 +234,7 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
     }
 
     // NOTE: This method is called from RecyclerViewDragDropManager
-    /*package*/ void onDragItemStarted(DraggingItemInfo draggingItemInfo, RecyclerView.ViewHolder holder, ItemDraggableRange range, int wrappedItemPosition, int itemMoveMode) {
+    /*package*/ void startDraggingItem(DraggingItemInfo draggingItemInfo, RecyclerView.ViewHolder holder, ItemDraggableRange range, int wrappedItemPosition, int itemMoveMode) {
         if (LOCAL_LOGD) {
             Log.d(TAG, "onDragItemStarted(holder = " + holder + ")");
         }
@@ -257,24 +258,28 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
         mDraggingItemViewHolder = holder;
         mDraggableRange = range;
         mItemMoveMode = itemMoveMode;
-
-        notifyDataSetChanged();
     }
 
     // NOTE: This method is called from RecyclerViewDragDropManager
-    /*package*/ void onDragItemFinished(boolean result) {
+    /*package*/ void onDragItemStarted() {
+        mCallingDragStarted = true;
+        mDraggableItemAdapter.onItemDragStarted(getDraggingItemInitialPosition());
+        mCallingDragStarted = false;
+    }
+
+    // NOTE: This method is called from RecyclerViewDragDropManager
+    /*package*/ void onDragItemFinished(
+            int draggingItemInitialPosition, int draggingItemCurrentPosition, boolean result) {
         if (LOCAL_LOGD) {
-            Log.d(TAG, "onDragItemFinished(result = " + result + ")");
+            Log.d(TAG, "onDragItemFinished(draggingItemInitialPosition = " + draggingItemInitialPosition +
+                    ", draggingItemCurrentPosition = " + draggingItemCurrentPosition + ", result = " + result + ")");
         }
 
         if (DEBUG_BYPASS_MOVE_OPERATION_MODE) {
             return;
         }
 
-        if (result && (mDraggingItemCurrentPosition != mDraggingItemInitialPosition)) {
-            // apply to wrapped adapter
-            mDraggableItemAdapter.onMoveItem(mDraggingItemInitialPosition, mDraggingItemCurrentPosition);
-        }
+        DraggableItemAdapter draggableItemAdapter = mDraggableItemAdapter;
 
         mDraggingItemInitialPosition = RecyclerView.NO_POSITION;
         mDraggingItemCurrentPosition = RecyclerView.NO_POSITION;
@@ -283,7 +288,12 @@ class DraggableItemWrapperAdapter<VH extends RecyclerView.ViewHolder> extends Si
         mDraggingItemViewHolder = null;
         mDraggableItemAdapter = null;
 
-        notifyDataSetChanged();
+        if (result && (draggingItemCurrentPosition != draggingItemInitialPosition)) {
+            // apply to wrapped adapter
+            draggableItemAdapter.onMoveItem(draggingItemInitialPosition, draggingItemCurrentPosition);
+        }
+
+        draggableItemAdapter.onItemDragFinished(draggingItemInitialPosition, draggingItemCurrentPosition, result);
     }
 
     @Override

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/draggable/RecyclerViewDragDropManager.java
@@ -762,8 +762,7 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
 
         startScrollOnDraggingProcess();
 
-        // raise onDragItemStarted() event
-        mWrapperAdapter.onDragItemStarted(mDraggingItemInfo, holder, mDraggableRange, wrappedItemPosition, mCurrentItemMoveMode);
+        mWrapperAdapter.startDraggingItem(mDraggingItemInfo, holder, mDraggableRange, wrappedItemPosition, mCurrentItemMoveMode);
 
         // setup decorators
         mWrapperAdapter.onBindViewHolder(holder, wrappedItemPosition);
@@ -785,6 +784,9 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         if (mEdgeEffectDecorator != null) {
             mEdgeEffectDecorator.reorderToTop();
         }
+
+        // raise onDragItemStarted() event
+        mWrapperAdapter.onDragItemStarted();
 
         if (mItemDragEventListener != null) {
             mItemDragEventListener.onItemDragStarted(mWrapperAdapter.getDraggingItemInitialPosition());
@@ -905,7 +907,10 @@ public class RecyclerViewDragDropManager implements DraggableItemConstants {
         if (mWrapperAdapter != null) {
             draggingItemInitialPosition = mWrapperAdapter.getDraggingItemInitialPosition();
             draggingItemCurrentPosition = mWrapperAdapter.getDraggingItemCurrentPosition();
-            mWrapperAdapter.onDragItemFinished(result);
+            mWrapperAdapter.onDragItemFinished(
+                    draggingItemInitialPosition,
+                    draggingItemCurrentPosition,
+                    result);
         }
 
 //        if (draggedItem != null) {

--- a/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableDraggableItemAdapter.java
+++ b/library/src/main/java/com/h6ah4i/android/widget/advrecyclerview/expandable/ExpandableDraggableItemAdapter.java
@@ -115,4 +115,47 @@ public interface ExpandableDraggableItemAdapter<GVH extends RecyclerView.ViewHol
      * @return Whether can be dropped to the specified position.
      */
     boolean onCheckChildCanDrop(int draggingGroupPosition, int draggingChildPosition, int dropGroupPosition, int dropChildPosition);
+
+    /**
+     * Callback method to be invoked when started dragging a group item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param groupPosition The position of the group item.
+     */
+    void onGroupDragStarted(int groupPosition);
+
+    /**
+     * Callback method to be invoked when started dragging a child item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param groupPosition The group position of the item.
+     * @param childPosition The child position of the item.
+     */
+    void onChildDragStarted(int groupPosition, int childPosition);
+
+    /**
+     * Callback method to be invoked when finished dragging a group item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param fromGroupPosition Previous position of the group item.
+     * @param toGroupPosition   New position of the group item.
+     * @param result       Indicates whether the dragging operation was succeeded.
+     */
+    void onGroupDragFinished(int fromGroupPosition, int toGroupPosition, boolean result);
+
+    /**
+     * Callback method to be invoked when finished dragging a child item.
+     *
+     * Call the {@link RecyclerView.Adapter#notifyDataSetChanged()} method in this callback to get the same behavior with v0.10.x or before.
+     *
+     * @param fromGroupPosition Previous group position of the item.
+     * @param fromChildPosition Previous child position of the item.
+     * @param toGroupPosition   New group position of the item.
+     * @param toChildPosition   New child position of the item.
+     * @param result       Indicates whether the dragging operation was succeeded.
+     */
+    void onChildDragFinished(int fromGroupPosition, int fromChildPosition, int toGroupPosition, int toChildPosition, boolean result);
 }


### PR DESCRIPTION
This pull request introduces new two callbacks to `DraggableItemAdapter`; `onItemDragStarted()` and `onItemDragFinished()`.

These callbacks are added to reduce internal `notifyDataSetChanged()` method calls. Now, users can fine control how invalidate items on dragging instead of the implicit `notifyDataSetChanged()` call.

Related issues/pull requests
- [BREAKING CHANGE] Add onItemSwipeStarted() method to SwipeableItemAdapter (#400) #416
- Only notify adapter to change the item being swiped #395
- NotifyDataSetChanged caused recycleview to blink #232
- swipe not so smooth like examples #129
